### PR TITLE
Fix confusing wording in tutorial

### DIFF
--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -90,7 +90,7 @@ function tutorial_init_pre() {
     text:     ["Now the aircraft is ready to take off. Click the aircraft again (or press up arrow once)",
                "and type &lsquo;takeoff&rsquo; to clear the aircraft to take off. It should slowly move",
                "down the runway; when it's going fast enough, it should lift off the ground and you should",
-               "see its altitude increasing. Meanwhile, click the arrow on the right."
+               "see its altitude increasing. Meanwhile, read the next step."
                ].join(" "),
     parse:    function(t) {
       return t.replace("{RUNWAY}", prop.aircraft.list[0].requested.runway);


### PR DESCRIPTION
The tutorial uses the word "arrow" several times to mean several different things - next step, speed up the simulation, and the arrow button on your keyboard.  This is a bit confusing.  I don't know what can be done without changing the image assets, but hopefully this PR can start it off.  

Nice job though.  
