### PR TITLE
Adding KMSP (Minneapolis/St. Paul International Airport)

### DIFF
--- a/assets/airports/kmsp.json
+++ b/assets/airports/kmsp.json
@@ -1,0 +1,150 @@
+{
+  "name": "Minneapolis/St. Paul International Airport",
+  "level": "hard",
+  "radio": "Minneapolis",
+  "icao": "KMSP",
+  "wind": {
+    "angle": 300,
+    "speed": 8
+  },
+  "fixes": {
+    "WASHY": [ -30, 18 ],
+    "HAMML": [ -50, 30 ],
+    "ALGIN": [ -80, 60 ],
+    "BOBEE": [ -10, 28 ],
+    "CHETZ": [ -16, 56 ],
+    "LORAH": [ 3, -38 ],
+    "ROZEE": [ 6, -62 ],
+    "NARCO": [ 30, -15 ],
+    "PIGZI": [ 50, -25 ],
+    "HASTI": [ 90, -45 ],
+    "KETAM": [ -60, -50 ],
+    "JALUN": [ 60, 50 ],
+    "TONKA": [-75, -5],
+    "WHIBR": [ 70, 15 ],
+    "MALLA": [ -24, -20 ],
+    "HILLS": [ 30, 25 ]
+  },
+  "runways": [
+    {
+      "name":        ["30R", "12L"],
+      "name_offset": [[1, 0], [0.2, 0.4]],
+      "position":    [4, 1],
+      "angle":       300,
+      "length":      8,
+      "delay":       [10, 30],
+      "ils":         [true, false]
+    },
+    {
+      "name":        ["30L", "12R"],
+      "name_offset": [[0.8, -0.2], [0, 0.4]],
+      "position":    [1, -1],
+      "angle":       300,
+      "length":      10,
+      "delay":       [10, 30],
+      "ils":         [true, false]
+    },
+    {
+      "name":        ["22", "4"],
+      "name_offset": [[0, 0], [0, 0.8]],
+      "position":    [0, -0.4],
+      "angle":       225,
+      "length":      11,
+      "delay":       [30, 20],
+      "ils":         [true, false]
+    },
+    {
+      "name":        ["35", "17"],
+      "name_offset": [[-2.4, -1], [0, 0]],
+      "position":    [-4.2, -2.4],
+      "angle":       170,
+      "length":      8,
+      "delay":       [20, 20],
+      "ils":         [true, false]
+    }
+  ],
+  "departures": {
+    "airlines": [
+      ["ual", 3], 
+      ["baw", 5],
+      ["cessna", 4]
+    ],
+    "frequency": [1, 3]
+  },
+  "arrivals": [
+    {
+      "heading":   180,
+      "airlines":  [
+        ["ual", 3],
+        ["baw", 1],
+        ["cessna", 2]
+      ],
+      "frequency": [4, 6],
+      "altitude":  [4000, 6000]
+    },
+    {
+      "angle":     90,
+      "heading":   135,
+      "airlines":  [
+        ["ual", 2],
+        ["baw", 5],
+        ["cessna", 1]
+      ],
+      "frequency": [2, 4],
+      "altitude":  [6000, 8000]
+    },
+    {
+      "angle":     270,
+      "heading":   45,
+      "airlines":  [
+        ["ual", 2],
+        ["baw", 5],
+        ["cessna", 20]
+      ],
+      "frequency": [2, 4],
+      "altitude":  [5000, 7000]
+    },
+    {
+      "angle":     270,
+      "heading":   0,
+      "airlines":  [
+        ["ual", 5],
+        ["baw", 1],
+        ["cessna", 3]
+      ],
+      "frequency": [2, 4],
+      "altitude":  [5000, 8000]
+    },
+    {
+      "angle":     180,
+      "heading":   270,
+      "airlines":  [
+        ["cessna", 20]
+      ],
+      "frequency": [2, 5],
+      "altitude":  [3000, 5000]
+    },
+    {
+      "angle":     45,
+      "heading":   90,
+      "airlines":  [
+        ["ual", 10],
+        ["baw", 1],
+        ["cessna", 20]
+      ],
+      "frequency": [10, 15],
+      "altitude":  [7000, 9000]
+    },
+    {
+      "angle":     315,
+      "heading":   180,
+      "airlines":  [
+        ["ual", 10],
+        ["baw", 10],
+        ["cessna", 1]
+      ],
+      "frequency": [3, 5],
+      "altitude":  [6000, 7000]
+    }
+  ]
+}

--- a/assets/airports/kmsp.json
+++ b/assets/airports/kmsp.json
@@ -28,7 +28,7 @@
   "runways": [
     {
       "name":        ["30R", "12L"],
-      "name_offset": [[1, 0], [0.2, 0.4]],
+      "name_offset": [[1, 0], [1.2, 0.4]],
       "position":    [4, 1],
       "angle":       300,
       "length":      8,
@@ -37,7 +37,7 @@
     },
     {
       "name":        ["30L", "12R"],
-      "name_offset": [[0.8, -0.2], [0, 0.4]],
+      "name_offset": [[0.8, -0.2], [1.6, 0.4]],
       "position":    [1, -1],
       "angle":       300,
       "length":      10,
@@ -55,9 +55,9 @@
     },
     {
       "name":        ["35", "17"],
-      "name_offset": [[-2.4, -1], [0, 0]],
+      "name_offset": [[0, 0], [-1.8, -2]],
       "position":    [-4.2, -2.4],
-      "angle":       170,
+      "angle":       350,
       "length":      8,
       "delay":       [20, 20],
       "ils":         [true, false]

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -374,6 +374,7 @@ function airport_init() {
   airport_load("kdbg");
   airport_load("ksra");
   airport_load("ksfo");
+  airport_load("kmsp");
 }
 
 function airport_ready() {


### PR DESCRIPTION
Based on FAA airport diagram and arrival procedures. The arrivals and departures are the same as the debug airport for now.
