### PR TITLE
Adding a space when using tab autocomplete for callsigns

### DIFF
--- a/assets/scripts/input.js
+++ b/assets/scripts/input.js
@@ -188,7 +188,7 @@ function tab_completion_cycle(opt) {
   } else {
     i = (i >= matches.length-1) ? 0 : i+1;
   }
-  $("#command").val(matches[i]);
+  $("#command").val(matches[i] + " ");
   prop.input.command = matches[i];
   prop.input.tab_compl.cycle_item = i;
   input_parse();


### PR DESCRIPTION
Adding a space after the auto-completed callsigns when using the tab autocomplete. 

This makes the sim more user-friendly and keeps the focus of the plane coordination.
