### PR TITLE
Fixing callsigns case when using up arrow (history)

### DIFF
--- a/assets/scripts/input.js
+++ b/assets/scripts/input.js
@@ -237,7 +237,7 @@ function input_history_prev() {
   input_history_clamp();
 
   var command = prop.input.history[prop.input.history_item] + ' ';
-  $("#command").val(command);
+  $("#command").val(command.toUpperCase());
   input_change();
 }
 


### PR DESCRIPTION
Minor fix,

When using the up arrow, the call sign that is being return is lowercase.
