### PR TITLE
ebbr.json doesn't exist, causing the load to fail

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -392,8 +392,6 @@ function airport_init() {
   airport_load("kjfk");
 //  airport_load("ksna");
 
-  // E*
-  airport_load("ebbr");
 }
 
 function airport_ready() {


### PR DESCRIPTION
ebbr.json is missing, causing http://zlsa.github.io/atc/ to be stuck on:

Failed to load resource: the server responded with a status of 404 (Not Found)
modules.js:125 [ WARN  ] Failed to get assets/airports/ebbr.json: 404

With retries every few seconds.

Either check in ebbr.json or the commit here will remove the reference to it.
