### PR TITLE
added "to" as a shortcut for "takeoff"

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -269,6 +269,7 @@ var Aircraft=Fiber.extend(function() {
       "direct",
 
       "takeoff",
+      "to",
 
       "wait",
       "taxi",
@@ -395,6 +396,7 @@ var Aircraft=Fiber.extend(function() {
       else if("taxi".indexOf(command) == 0)     command = "wait";
 
       else if("takeoff".indexOf(command) == 0)  command = "takeoff";
+      else if("to".indexOf(command) == 0)       command = "takeoff";
 
       else if("land".indexOf(command) == 0)     command = "land";
 


### PR DESCRIPTION
I don´t know if "to" should also be added to

```
var DEFERRED_COMMANDS = ["takeoff"];
```

What is the purpose of this?
It is pushed to "deferred" afterwards, passed to "run()", passed to "runTakeoff()" but I don´t see it being used there.
