### PR TITLE
Fix lpad for inputs longer than width

### DIFF
--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -177,6 +177,7 @@ function mod(a, b) {
 };
 
 function lpad(n, width) {
+  if (n.toString().length >= width) return n.toString();
   var x = "0000000000000" + n;
   return x.substr(x.length-width, width);
 }


### PR DESCRIPTION
lpad incorrectly takes the right most characters if the input string is longer than the width.  I'm presuming the intent is to pad to at least the given width.  This fixes it to return the string unmodified if it's at least width characters long.

Reproduce:
-Assign aircraft an altitude of 10,000, radar tag will show altitude as 00.
