### PR TITLE
Center map position on zoom

### DIFF
--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -10,15 +10,21 @@ function ui_init_pre() {
 }
 
 function ui_zoom_out() {
+  var lastpos = [round(pixels_to_km(prop.canvas.panX)), round(pixels_to_km(prop.canvas.panY))];
   prop.ui.scale *= 0.9;
   if(prop.ui.scale < prop.ui.scale_min) prop.ui.scale = prop.ui.scale_min;
   ui_after_zoom();
+  prop.canvas.panX = round(km(lastpos[0]));
+  prop.canvas.panY = round(km(lastpos[1]));
 }
 
 function ui_zoom_in() {
+  var lastpos = [round(pixels_to_km(prop.canvas.panX)), round(pixels_to_km(prop.canvas.panY))];
   prop.ui.scale /= 0.9;
   if(prop.ui.scale > prop.ui.scale_max) prop.ui.scale = prop.ui.scale_max;
   ui_after_zoom();
+  prop.canvas.panX = round(km(lastpos[0]));
+  prop.canvas.panY = round(km(lastpos[1]));
 }
 
 function ui_zoom_reset() {


### PR DESCRIPTION
I noticed that the zoom, the map is centered on the zero coordinates, which is slightly inconvenient.
This code stores the position of the map in the display region, followed by zoom, and after the map is moved to the original position.
As a result, the zoom always comes from the visual center.
I think it's a little better and more comfortable.

Sorry for bad english.
