### PR TITLE
Continue turning to assigned heading during runway acquisition - Fixe…

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -908,6 +908,9 @@ var Aircraft=Fiber.extend(function() {
             console.log("aborted landing after ILS lost");
             prop.game.score.abort.landing += 1;
           }
+        } else {
+          this.target.heading = this.requested.heading;
+          this.target.turn = this.requested.turn;
         }
 
         //this has to be outside of the glide slope if, as the plane is no


### PR DESCRIPTION
…s #84 

This makes the command equivalent to an ATC command of 'turn left to x until established on the localizer'.
