### PR TITLE
Calculate aircraft turn rate based on speed

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1015,7 +1015,11 @@ var Aircraft=Fiber.extend(function() {
         // TURNING
 
         if(this.altitude > 10) {
-          var turn_amount = this.model.rate.turn * game_delta();
+          // Perform standard turns 3 deg/s or 25 deg bank, whichever
+          // requires less bank angle.
+          // Formula based on http://aviation.stackexchange.com/a/8013
+          var turn_rate = clamp(0, 1 / (this.speed / 8.883031), 0.0523598776);
+          var turn_amount = turn_rate * game_delta();
           var offset = angle_offset(this.target.heading, this.heading);
           if(abs(offset) < turn_amount) {
             this.heading = this.target.heading;


### PR DESCRIPTION
This implements a [standard rate turn](https://en.wikipedia.org/wiki/Standard_rate_turn) and would fix #88.  It simulates an aircraft turning at either 3 degrees/second or 25 degrees of bank, whichever is the lower turn rate.

The main thing I find with this change is that the different aircraft models are no longer noticeable, except for the difference between jets and general aviation common speeds.  I find it an acceptable trade-off in terms of increased realism and ability to handle quantity of traffic, but it does give a different character to the game which may not be desirable.
