### PR TITLE
Remove duplicate aircraft movement

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1084,11 +1084,6 @@ var Aircraft=Fiber.extend(function() {
       var angle = this.heading;
       this.position[0] += (sin(angle) * (this.speed * 0.000514)) * game_delta();
       this.position[1] += (cos(angle) * (this.speed * 0.000514)) * game_delta();
-
-      var wind_drift = [0, 0];
-
-      this.position[0] += (sin(angle) * (this.speed * 0.000514)) * game_delta();
-      this.position[1] += (cos(angle) * (this.speed * 0.000514)) * game_delta();
     },
     updateWarning: function() {
       if(this.isTaxiing()) return;

--- a/assets/scripts/game.js
+++ b/assets/scripts/game.js
@@ -7,7 +7,7 @@ function game_init_pre() {
 
   prop.game.speedup=1;
 
-  prop.game.frequency = 0.5;
+  prop.game.frequency=1;
 
   prop.game.time=0;
   prop.game.delta=0;


### PR DESCRIPTION
Aircraft are moving twice the speed which they should be based on assigned airspeeds in knots.  This looks to be unintentional and is fixed by this patch.

Given the difference in gameplay, I'm wondering if this should be offset somehow.  The immediate thought is defaulting to a 2x warp so real time movement ends up approximately the same.
