### PR TITLE
Add rate command

### DIFF
--- a/assets/scripts/input.js
+++ b/assets/scripts/input.js
@@ -330,6 +330,14 @@ function input_run() {
       ui_airport_toggle();
     }
     return true;
+  } else if(prop.input.callsign == "rate") {
+    if (prop.input.data) {
+      var freq = parseFloat(prop.input.data);
+      if (freq && freq > 0) {
+        prop.game.frequency = freq;
+      }
+    }
+    return true;
   }
 
   var matches = 0;


### PR DESCRIPTION
Allow adjusting the rate of aircraft spawning.  At this time
the standard rate is 0.5, smaller numbers will cause aircraft to
spawn less frequently.  Larger numbers cause aircraft to spawn
more frequently.

Closes #74 and possibly #108
