### PR TITLE
Make wind at KSFO more realistic

### DIFF
--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -5,7 +5,7 @@
   "icao": "KSFO",
   "ctr_radius": 80,
   "wind": {
-    "angle": 130,
+    "angle": 310,
     "speed": 5
   },
   "fixes": {


### PR DESCRIPTION
Wind at KSFO pretty consistently comes from the northwest instead of from the southeast.
