### PR TITLE
Specify aircraft in front of current when failing takeoff command

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -642,7 +642,7 @@ var Aircraft=Fiber.extend(function() {
         return ["ok", "cleared for takeoff", ""];
       } else {
         var waiting = runway.isWaiting(this, this.requested.runway);
-        return ["fail", "number "+waiting+" behind "+runway.waiting[runway.getEnd(this.requested.runway)][waiting+1].getRadioCallsign(), ""];
+        return ["fail", "number "+waiting+" behind "+runway.waiting[runway.getEnd(this.requested.runway)][waiting-1].getRadioCallsign(), ""];
       }
 
     },


### PR DESCRIPTION
Fixes an indexing error which caused the last aircraft in line to not respond when telling it to takeoff with aircraft waiting in front.  Also accurately reports the aircraft waiting in front.

Related to #105.
