### PR TITLE
Fix collision warning with taxiing aircraft

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1118,6 +1118,7 @@ var Aircraft=Fiber.extend(function() {
         // Check if the aircraft are on a potential collision course
         // on the runway
         if ((this.isLanded() || this.altitude < 990) &&
+            !other.isTaxiing() &&
             (other.isLanded() || (other.altitude < 990)))
         {
           var airport = airport_get();


### PR DESCRIPTION
This fixes my bug where a collision warning is issued between aircraft on the runway and aircraft taxiing from the apron to a runway.
