### PR TITLE
Remove redundant calls to aircraft_visible

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1474,18 +1474,19 @@ function aircraft_update() {
   for(var i=prop.aircraft.list.length-1;i>=0;i--) {
     var remove = false;
     var aircraft = prop.aircraft.list[i];
-    if(!aircraft_visible(aircraft) && aircraft.category == "departure" && aircraft.inside_ctr) {
+    var is_visible = aircraft_visible(aircraft);
+    if(!is_visible && aircraft.category == "departure" && aircraft.inside_ctr) {
       ui_log(aircraft.getRadioCallsign() + " leaving radar coverage");
       prop.game.score.departure += 1;
       console.log("departing aircraft no longer visible");
       aircraft.inside_ctr = false;
     }
-    if(!aircraft_visible(aircraft) && aircraft.category == "arrival" && aircraft.inside_ctr) {
+    if(!is_visible && aircraft.category == "arrival" && aircraft.inside_ctr) {
       ui_log(aircraft.getRadioCallsign() + " leaving radar coverage");
       console.log("arriving aircraft no longer visible. YU FAIL");
       aircraft.inside_ctr = false;
     }
-    if(aircraft.category == "arrival" && aircraft_visible(aircraft) && !aircraft.inside_ctr) {
+    if(aircraft.category == "arrival" && is_visible && !aircraft.inside_ctr) {
       var position = "";
       var distance = round(distance2d([0, 0], aircraft.position) * 0.62);
       position += distance + " mile" + s(distance);


### PR DESCRIPTION
aircraft_update() made multiple calls to determine if the aircraft is visible, rather than calling once and caching the result. The cost of these extra calls show up when the app is profiled.
