### PR TITLE
Fix scope of length variable in updateRunway; fixes #152

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -325,7 +325,7 @@ var Airport=Fiber.extend(function() {
       if(timeout)
         arrival.timeout = game_timeout(this.addAircraftArrival, crange(0, Math.random(), 1, arrival.frequency[0] / prop.game.frequency, arrival.frequency[1] / prop.game.frequency), this, [arrival, null, true]);
     },
-    updateRunway: function() {
+    updateRunway: function(length) {
       if(!length) length = 0;
       var wind = this.getWind();
       var headwind = {};


### PR DESCRIPTION
The test

```
if(!length) length = 0;
```

previously referred to some global variable `length`, not a runway length as intended. This caused unpredictable results and a sequence of problems:
- `this.runway` got set to the null string in `updateRunway()`
- when new aircraft were spawned, `Aircraft.complete()` would call `selectRunway` and get the null string
- `complete()` would call `updateStrip()` which would not display the aircraft at the apron. This is because the test `if(this.requested.runway) {` was false.

There may be bigger changes/cleanup possible, since `updateRunway()` is never called with an argument, although perhaps it was intended to. But this one line fix solves the problem for now.
