### PR TITLE
Runway centerline intercept improvements

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -918,6 +918,7 @@ var Aircraft=Fiber.extend(function() {
             }
             this.updateStrip();
             this.requested.turn = null;
+            this.requested.heading = angle;
             this.target.turn = null;
           }
 

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -381,7 +381,7 @@ function canvas_draw_future_track(cc, aircraft) {
   prop.game.delta = 5;
   future_track = [];
   for(i = 0; i < 60; i++) {
-    twin.update();
+    twin.update(true);
     ils_locked = twin.requested.runway && twin.category == "arrival" && twin.mode == "landing";
     future_track.push([twin.position[0], twin.position[1], ils_locked]);
     if( ils_locked && twin.altitude < 500)

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -375,13 +375,13 @@ function canvas_draw_aircraft(cc, aircraft) {
 
 // Run physics updates into the future, draw magenta track
 function canvas_draw_future_track(cc, aircraft) {
-  twin = $.extend(true, {}, aircraft);
-  twin.updateStrip = function(){}; // ignore any calls to updateStrip() for the twin
+  var twin = $.extend(true, {}, aircraft);
+  twin.projected = true;
   save_delta = prop.game.delta;
   prop.game.delta = 5;
   future_track = [];
   for(i = 0; i < 60; i++) {
-    twin.update(true);
+    twin.update();
     ils_locked = twin.requested.runway && twin.category == "arrival" && twin.mode == "landing";
     future_track.push([twin.position[0], twin.position[1], ils_locked]);
     if( ils_locked && twin.altitude < 500)

--- a/assets/scripts/game.js
+++ b/assets/scripts/game.js
@@ -37,7 +37,9 @@ function game_init_pre() {
     abort: {
       landing: 0,
       taxi: 0
-    }
+    },
+
+    violation: 0,
   };
 
 }
@@ -58,6 +60,8 @@ function game_get_score() {
   score -= prop.game.score.abort.landing * 5;
 
   score -= prop.game.score.abort.taxi * 2;
+
+  score -= prop.game.score.violation;
 
   return score;
 }


### PR DESCRIPTION
This is a follow on from #158.  The aim is to have aircraft intercept and track the extended runway centerline instead of 'funneling' into the threshold. It is modeled after ILS intercept procedures and attempts to balance ILS/aircraft capabilities with ATC restrictions.

The major changes are:
- Reducing capture width from 30 degrees to 10 degrees either side of center.
- Include a negative score with announcement for intercept vectors over 30 degrees from runway angle.
- Set assigned heading to the runway heading on intercept (fixes tracking off the runway on landing)
- Make Aircraft.update() aware of path projection on the canvas to avoid spurious warnings and incorrect score updates.
