### PR TITLE
Implement select all aircraft, fixes #175

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -236,6 +236,8 @@ var Aircraft=Fiber.extend(function() {
       this.html.remove();
     },
     matchCallsign: function(callsign) {
+      if( callsign === '*')
+        return true;
       callsign = callsign.toLowerCase();
       var this_callsign = this.getCallsign().toLowerCase();
       if(this_callsign.indexOf(callsign) == 0) return true;


### PR DESCRIPTION
All aircraft can be selected (and their future tracks can be viewed) by entering '*'.
