### PR TITLE
Add ability to spawn arrival aircraft with STAR fix list

### DIFF
--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -109,7 +109,8 @@
   },
   "arrivals": [
     {
-      "radial":    45,
+      "radial":   45,
+      "heading":  170,
       "speed":    250,
       "fixes":   ["MOVDD", "RISTI", "CEDES", "ARCHI"],
       "airlines":  [

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -109,10 +109,10 @@
   },
   "arrivals": [
     {
-      "radial":   45,
+      "radial":   60,
       "heading":  170,
       "speed":    250,
-      "fixes":   ["MOVDD", "RISTI", "CEDES", "ARCHI"],
+      "fixes":   ["MOVDD", "RISTI", "CEDES"],
       "airlines":  [
         ["ual", 1],
         ["baw", 1],

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -46,7 +46,19 @@
     "UPEND": ["N38.032",  "W122.097"],
     "STINS": ["N37.823667", "W122.7566667"],
     "LOZIT": ["N37.899333", "W122.6731667"],
-    "SFO":   ["N37.6195", "W122.3738333"]
+    "SFO":   ["N37.6195", "W122.3738333"],
+    
+    "SEPDY":   ["N37.685667", "W122.363667"],
+    "SENZY":   ["N37.666500", "W122.485167"],
+    "ZUPAX":   ["N37.254497", "W122.588508"],
+    "NORMM":   ["N37.720208", "W122.613172"],
+    "LUVVE":   ["N37.497367", "W122.231053"],
+    "MOLEN":   ["N37.997872", "W123.086797"],
+    "WAMMY":   ["N37.541064", "W122.724056"],
+    "SEGUL":   ["N36.963036", "W122.572131"],
+    "PORTE":   ["N37.489786", "W122.474578"],
+    "SASLY":   ["N37.678500", "W122.334500"],
+    "REBAS":   ["N37.940683", "W122.383667"]
   },
   "runways":[
     {
@@ -89,13 +101,16 @@
       ["ups", 2]
     ],
     "destinations": [
-      67, 170, 340
+      290, 180, 340
     ],
-    "frequency": [2.8, 3.2]
+    "type": "random",
+    "offset": 0,
+    "frequency": 38
   },
   "arrivals": [
     {
       "radial":    45,
+      "speed":    250,
       "fixes":   ["MOVDD", "RISTI", "CEDES", "ARCHI"],
       "airlines":  [
         ["ual", 1],
@@ -103,22 +118,28 @@
         ["dal", 1],
         ["aal", 1]
       ],
-      "frequency": [6, 8],
-      "altitude":  [7000, 9000]
+      "type": "wave",
+      "offset": 0,
+      "frequency": 12,
+      "altitude":  10000
     },
     {
-      "radial":    90,
+      "radial":   90,
+      "speed":    250,
       "fixes":    ["FAITH"],
       "airlines":  [
         ["ual", 2],
         ["baw", 5],
         ["cessna", 1]
       ],
-      "frequency": [10, 15],
-      "altitude":  [8000, 10000]
+      "type": "random",
+      "offset": 5,
+      "frequency": 6,
+      "altitude":  10000
     },
     {
-      "radial":    145,
+      "radial":   145,
+      "speed":    250,
       "fixes":    ["SKUNK", "BOLDR", "MENLO"],
       "airlines":  [
         ["ual", 4],
@@ -126,19 +147,23 @@
         ["dal", 2],
         ["aca", 1]
       ],
-      "frequency": [3.5, 4],
-      "altitude":  [8000, 10000]
+      "type": "wave",
+      "offset": 3,
+      "frequency": 12,
+      "altitude":  10000
     },
     {
-      "radial":    315,
+      "radial":   315,
+      "speed":    250,
       "fixes":    ["PYE", "DUXBY", "SFO"],
       "airlines":  [
         ["ual", 10],
         ["baw", 10],
         ["fastga", 1]
       ],
-      "frequency": [8, 10],
-      "altitude":  [8000, 10000]
+      "type": "random",
+      "frequency": 6,
+      "altitude":  10000
     }
   ]
 }

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -96,7 +96,7 @@
   "arrivals": [
     {
       "radial":    45,
-      "heading":   200,
+      "fixes":   ["MOVDD", "RISTI", "CEDES", "ARCHI"],
       "airlines":  [
         ["ual", 1],
         ["baw", 1],
@@ -108,7 +108,7 @@
     },
     {
       "radial":    90,
-      "heading":   270,
+      "fixes":    ["FAITH"],
       "airlines":  [
         ["ual", 2],
         ["baw", 5],
@@ -119,7 +119,7 @@
     },
     {
       "radial":    145,
-      "heading":   325,
+      "fixes":    ["SKUNK", "BOLDR", "MENLO"],
       "airlines":  [
         ["ual", 4],
         ["baw", 3],
@@ -131,7 +131,7 @@
     },
     {
       "radial":    315,
-      "heading":   130,
+      "fixes":    ["PYE", "DUXBY", "SFO"],
       "airlines":  [
         ["ual", 10],
         ["baw", 10],

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -824,6 +824,11 @@ var Aircraft=Fiber.extend(function() {
       else              this.requested.speed = this.model.speed.cruise;
 
       if(data.destination) this.destination = data.destination;
+      if(data.fixes && data.fixes.length > 0) {
+        this.requested.fix = data.fixes;
+        this.requested.turn = null;
+        this.requested.navmode = "fix";
+      }
 
       if(this.category == "departure" && this.isLanded()) {
         this.speed = 0;

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -248,6 +248,8 @@ var Aircraft=Fiber.extend(function() {
       var aircraft_dist = distance2d(this.position, [0,0]);
       var closerFixes = fixes.filter( function(f) {
         var fix = airport_get().getFix(f);
+        if( fix == null )
+          throw "Fix not found: " + f;
         return distance2d(fix, [0,0]) < aircraft_dist;
       });
       // Revert to heading mode if all fixes are eliminated (eg. spawn close to origin)

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -825,7 +825,7 @@ var Aircraft=Fiber.extend(function() {
 
       if(data.destination) this.destination = data.destination;
       if(data.fixes && data.fixes.length > 0) {
-        this.requested.fix = data.fixes;
+        this.requested.fix = data.fixes.slice();
         this.requested.turn = null;
         this.requested.navmode = "fix";
       }

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -209,7 +209,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
       if(start_flag) // At start, spawn aircraft closer but outside ctr_radius
         distance = this.airport.ctr_radius + random(10, 20);
       else
-        distance = 2*this.airport.ctr_radius - random(2, 18);
+        distance = 2*this.airport.ctr_radius - 2;
       var position = [sin(radial) * distance, cos(radial) * distance];
 
       var altitude = random(this.altitude[0] / 1000,

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -98,7 +98,7 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
         airline:   choose_weight(this.airlines),
         altitude:  altitude,
         heading:   this.heading,
-        fixes:     this.fixes.slice(),
+        fixes:     this.fixes,
         message:   message,
         position:  position,
         speed:     this.speed

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -128,6 +128,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
       this.altitude = [1000, 1000];
       this.frequency = [0, 0];
       this.heading = null;
+      this.fixes = [];
       this.radial = [0, 0];
       this.speed = 200;
 
@@ -140,6 +141,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
     // altitude: {array or integer} Altitude in feet or range of altitudes
     // frequency: {array or integer} Frequency in aircraft/hour or range of frequencies
     // heading: {array or integer} Heading in degrees or range of headings
+    // fixes: {array} Set of fixes to traverse (eg. for STARs)
     // radial: {array or integer} Radial in degrees or range of radials
     // speed: {integer} Speed in knots of spawned aircraft
     parse: function(options) {
@@ -161,6 +163,8 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
         this.heading[0] = radians(options.heading[0]);
         this.heading[1] = radians(options.heading[1]);
       }
+      if (options.fixes)
+        this.fixes = options.fixes;
 
       if (typeof options.radial == typeof 0)
         this.radial = [radians(options.radial), radians(options.radial)];
@@ -224,6 +228,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
         airline:   choose_weight(this.airlines),
         altitude:  altitude,
         heading:   heading,
+        fixes:     this.fixes,
         message:   message,
         position:  position,
         speed:     this.speed

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -63,28 +63,26 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
 
       if(Math.random() > 0.3) {
         delay = Math.random() * 0.1;
-        game_timeout(this.spawnAircraft, delay, this, [null, false]);
+        game_timeout(this.spawnAircraft, delay, this, [false, false]);
       }
       this.timeout =
-        game_timeout(this.spawnAircraft, delay, this, [random(0.5, 0.8), true]);
+        game_timeout(this.spawnAircraft, delay, this, [true, true]);
     },
 
     // Create an aircraft and schedule next arrival if appropriate
     spawnAircraft: function(args) {
-      var offset  = args[0];
-      var timeout = args[1];
-      if(timeout == undefined) timeout=false;
-      if(!offset) offset = 1;
+      var start_flag   = args[0];
+      var timeout_flag = args[1] || false;
 
       // Set heading within 15 degrees of specified
       var wobble   = radians(15);
       var radial   = this.radial + random(-wobble, wobble);
-
-      // Set location 2-18km inside of the radar coverage line
-      var distance = (2*this.airport.ctr_radius - 18) * offset + random(16);
-      var position = [0, 0];
-      position[0] += sin(radial) * distance;
-      position[1] += cos(radial) * distance;
+      var distance;
+      if(start_flag) // At start, spawn aircraft closer but outside ctr_radius
+        distance = this.airport.ctr_radius + random(10, 20);
+      else
+        distance = 2*this.airport.ctr_radius - random(2, 18);
+      var position = [sin(radial) * distance, cos(radial) * distance];
 
       var altitude = random(this.altitude[0] / 1000,
                             this.altitude[1] / 1000);
@@ -104,12 +102,12 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
         speed:     this.speed
       });
 
-      if(timeout) {
+      if(timeout_flag) {
         this.timeout =
           game_timeout(this.spawnAircraft,
                        this.nextInterval(),
                        this,
-                       [null, true]);
+                       [false, true]);
       }
     },
     nextInterval: function() {
@@ -188,33 +186,31 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
 
       if(Math.random() > 0.3) {
         delay = Math.random() * 0.1;
-        game_timeout(this.spawnAircraft, delay, this, [null, false]);
+        game_timeout(this.spawnAircraft, delay, this, [false, false]);
       }
       this.timeout =
-        game_timeout(this.spawnAircraft, delay, this, [random(0.5, 0.8), true]);
+        game_timeout(this.spawnAircraft, delay, this, [true, true]);
     },
 
     // Create an aircraft and schedule next arrival if appropriate
     spawnAircraft: function(args) {
-      var offset  = args[0];
-      var timeout = args[1];
-      if(timeout == undefined) timeout=false;
-      if(!offset) offset = 1;
+      var start_flag   = args[0];
+      var timeout_flag = args[1] || false;
 
       // Set heading within 15 degrees of specified
       var radial   = random(this.radial[0], this.radial[1])
 
-      var heading = null
+      var heading = null;
       if (this.heading)
         heading = random(this.heading[0], this.heading[1]);
       else
         heading = radial + Math.PI;
-
-      // Set location 2km inside of the radar coverage line
-      var distance = (2*this.airport.ctr_radius - 2) * offset;
-      var position = [0, 0];
-      position[0] += sin(radial) * distance;
-      position[1] += cos(radial) * distance;
+      var distance;
+      if(start_flag) // At start, spawn aircraft closer but outside ctr_radius
+        distance = this.airport.ctr_radius + random(10, 20);
+      else
+        distance = 2*this.airport.ctr_radius - random(2, 18);
+      var position = [sin(radial) * distance, cos(radial) * distance];
 
       var altitude = random(this.altitude[0] / 1000,
                             this.altitude[1] / 1000);
@@ -234,7 +230,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
         speed:     this.speed
       });
 
-      if(timeout) {
+      if(timeout_flag) {
         this.timeout =
           game_timeout(this.spawnAircraft,
                        this.nextInterval(),

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -23,6 +23,7 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
       this.altitude = 0;
       this.frequency = [0, 0];
       this.heading = 0;
+      this.fixes = [];
       this.radial = 0;
       this.speed = null;
 
@@ -45,6 +46,8 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
         options.heading = (options.radial + 180) % 360;
 
       this.heading = radians(options.heading);
+      if( options.fixes )
+        this.fixes = options.fixes;
       this.radial = radians(options.radial);
       this.speed = options.speed;
     },
@@ -95,6 +98,7 @@ zlsa.atc.ArrivalDefault = Fiber.extend(function(base) {
         airline:   choose_weight(this.airlines),
         altitude:  altitude,
         heading:   this.heading,
+        fixes:     this.fixes.slice(),
         message:   message,
         position:  position,
         speed:     this.speed


### PR DESCRIPTION
Proposed set of changes using KSFO as a test airport (checked items are done):
- [x] Add ability to spawn arrival aircraft with a list of fixes, rather than a heading
- [x] Update KSFO to use STARs
- [x] Test KSFO
- [x] Update KSFO with cyclic/wave arrivals (#144)
- [x] Adjust KSFO departure and arrival rates (#156)
- [x] Play test
- [x] *Add error checking for invalid fix names
- [x] *Ensure aircraft spawn outside of ctr_radius

Suggestions welcome. (I would ordinarily do this as a set of commits, then rebase and squash into a single commit and send a pull request at the end. But I wanted to try it in stages.)
