### PR TITLE
Fix mismatched 2d context save/restore

### DIFF
--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -305,7 +305,6 @@ function canvas_draw_aircraft(cc, aircraft) {
   dpr = window.devicePixelRatio || 1;
   if (dpr > 1) 
     trailling_length *= round(dpr);
-  cc.restore();
 
   cc.save();
   if (!aircraft.inside_ctr)
@@ -323,7 +322,6 @@ function canvas_draw_aircraft(cc, aircraft) {
   }
   cc.restore();
 
-  cc.save();
   if(aircraft.position_history.length > trailling_length) aircraft.position_history = aircraft.position_history.slice(aircraft.position_history.length - trailling_length, aircraft.position_history.length);
 
   if( aircraft.isPrecisionGuided() && aircraft.altitude > 1000) {


### PR DESCRIPTION
A second pair of eyes on this code would be good -

Ordinarily canvas 2D contexts have `save()` and `restore()` in matched pairs. `canvas_draw_aircraft()` did a `restore()` first for no apparent reason, and there is a later `save()` with no match. (Not clear if this is causing contexts to leak memory, but it looks wrong).

These two lines were removed, and tested to verify that there was no change in aircraft appearance. The other save/restore pairs in the file look to be ok.
