### PR TITLE
Add LAX airport

### DIFF
--- a/assets/airports/klax.json
+++ b/assets/airports/klax.json
@@ -1,0 +1,211 @@
+{
+  "name": "Los Angeles International Airport (WIP)",
+  "level": "hard",
+  "radio": "Los Angeles",
+  "icao": "KLAX",
+  "magnetic_north": 12.3,
+  "ctr_radius": 80,
+  "position": ["N33d56m33.13", "W118d24m29.07" ],
+  "wind": {
+    "angle": 260,
+    "speed": 10
+  },
+  "fixes": {
+    "PFILA": ["N34d01m12.69", "W117d41m50.18"],
+    "SALWA": ["N34d00m47.72", "W117d46m8.30"],
+    "WLNUT": ["N34d00m22.60", "W117d50m26.38"],
+    "HURLR": ["N33d59m57.33", "W117d54m44.42"],
+    "JULLI": ["N33d58m44.08", "W118d07m03.59"],
+    "BOUBY": ["N33d58m27.94", "W118d09m44.83"],
+    "SUTIE": ["N33d57m47.14", "W118d16m29.60"],
+    "CORTY": ["N33d57m13.85", "W118d21m57.13"],
+    
+    "KRAIN": ["N34d00m21.51", "W117d41m30.20"],
+    "TAROC": ["N33d59m57.25", "W117d45m41.11"],
+    "DYMMO": ["N33d59m32.70", "W117d49m51.96"],
+    "FUELR": ["N33d59m09.67", "W117d53m48.79"],
+    "GAATE": ["N33d58m04.44", "W118d04m48.38"],
+    "HUNDA": ["N33d57m32.95", "W118d10m03.20"],
+    "LIMMA": ["N33d56m54.40", "W118d16m25.43"],
+    "LADLE": ["N33d56m27.28", "W118d20m52.39"],
+
+    "OTTES": ["N33d55m26.46", "W118d39m18.34"],
+    "GUPPI": ["N33d56m11.06", "W118d32m08.72"],
+    
+    "SKOLL": ["N34d01m19.20", "W117d41m54.95"],
+    "DECOR": ["N34d00m54.23", "W117d46m13.07"],
+    "BREEA": ["N34d00m29.11", "W117d50m31.16"],
+    "PALAC": ["N34d00m03.83", "W117d54m49.20"],
+    "MERCE": ["N33d58m50.84", "W118d07m05.76"],
+    "JETSA": ["N33d57m53.10", "W118d16m39.66"],
+    "ARBIE": ["N33d57m18.09", "W118d22m23.93"],
+    
+    "NATHN": ["N33d55m34.95", "W118d39m03.69"],
+    "ALISN": ["N33d56m19.52", "W118d31m54.33"],
+    
+    "BCOVE": ["N34d00m57.45", "W117d36m39.03"],
+    "LYCOM": ["N34d00m29.60", "W117d41m28.95"],
+    "TAANK": ["N34d00m05.33", "W117d45m39.87"],
+    "JURPE": ["N33d59m40.93", "W117d49m50.74"],
+    "MUSIK": ["N33d59m17.43", "W117d53m50.89"],
+    "FALLT": ["N33d58m12.40", "W118d04m48.47"],
+    "SHELL": ["N33d57m43.16", "W118d09m40.82"],
+    "FOGLA": ["N33d57m02.36", "W118d16m25.54"],
+    "GRIMY": ["N33d56m42.10", "W118d19m45.18"],
+    
+    "STEMS": ["N33d53m41.31", "W118d48m47.54"],
+    "FEKIL": ["N33d54m47.35", "W118d38m18.87"],
+    "TURKA": ["N33d55m31.95", "W118d31m09.32"],
+
+    "OLAFF": ["N33d53m33.39", "W118d48m46.95"],
+    "TIMSE": ["N33d54m39.51", "W118d38m17.58"],
+    "FUMBL": ["N33d55m24.13", "W118d31m07.93"],
+    
+    "KIMMO": ["N34d24m36.57", "W118d25m02.17"],
+    "DARTS": ["N34d09m21.77", "W118d16m10.54"],
+    "SXC":   ["N33d22m30.20", "W118d25m11.68"],
+    "CFBZK": ["N33d18m13.20", "W117d52m48.60"],
+    "CWARD": ["N33d23m02.45", "W117d54m33.38"],
+    "SLI":   ["N33d46m59.87", "W118d03m17.12"],
+    "RUSTT": ["N34d02m53.62", "W117d14m32.83"],
+    "HABSO": ["N34d02m24.41", "W117d19m51.57"],
+    "RIIVR": ["N34d01m42.17", "W117d27m23.82"],
+    "FIM":   ["N34d21m24.10", "W118d52m52.65"],
+    "SADDE": ["N34d02m20.38", "W118d45m52.68"],
+    "SMO":   ["N34d00m36.88", "W118d27m24.18"],
+    "VISTA": ["N33d13m08.66", "W117d14m04.19"],
+    "OCN":   ["N33d14m26.31", "W117d25m03.76"],
+    "SHIVE": ["N33d15m58.34", "W117d51m59.82"],
+    "CWARD": ["N33d23m02.45", "W117d54m33.38"],
+    "MADOW": ["N33d37m24.97", "W117d59m47.04"],
+    
+    "LAX":   ["N33.93316666666667", "W118.432"],
+    "KEGGS": ["N34d00m30.41", "W118d17m58.53"],
+    "DINTY": ["N33d28m58.49", "W122d35m02.38"],
+    "FICKY": ["N31d33m27.38", "W121d23m30.47"],
+    "COSER": ["N33d34m47.57", "W117d58m49.66"],
+    "CARDI": ["N33d08m11.64", "W117d25m18.95"],
+    "SEBBY": ["N34d05m22.87", "W117d46m37.12"]
+  },
+  "runways":[
+    {
+      "name":        ["7L", "25R"],
+      "name_offset": [[0, 0], [0, 0]],
+      "end":    [ ["N33.9358305833", "W118.41934175"], ["N33.9398772", "W118.37977695"]],
+      "length":      3.685,
+      "ils":         [true, true]
+    },
+    {
+      "name":        ["7R", "25L"],
+      "name_offset": [[0, -0.2], [0, -0.3]],
+      "end":    [["N33.9336493833", "W118.4190183333"], ["N33.93736303333", "W118.382713916667"]],
+      "length":      3.382,
+      "ils":         [true, true]
+    },
+    {
+      "name":        ["6R", "24L"],
+      "name_offset": [[0.3, -0.1], [0.4, 0]],
+      "end":    [["N33.94674746666667","W118.43532721666667" ], ["N33.95019445", "W118.40166866666667"] ],
+      "length":      3.135,
+      "ils":         [true, true]
+    },
+    {
+      "name":        ["6L", "24R"],
+      "name_offset": [[-0.3, 0], [-0.3, 0.1]],
+      "end":    [["N33.94911246666667", "W118.43115986666667"], ["N33.95210391666667","W118.40194891666667"]], 
+      "length":      2.721,
+      "ils":         [true, true]
+    }
+  ],
+  "departures": {
+    "airlines": [
+      ["ual", 11],
+      ["baw", 9],
+      ["ups", 2],
+      ["fdx", 2]
+    ],
+    "destinations": [
+      40, 50, 120, 215
+    ],
+    "type": "random",
+    "offset": 0,
+    "frequency": 34
+  },
+  "arrivals": [
+    {
+      "_name":  "Kimmo 3",
+      "radial":   350,
+      "heading":  170,
+      "speed":    250,
+      "fixes":   ["KIMMO", "DARTS"],
+      "airlines":  [
+        ["ual", 1],
+        ["baw", 1],
+        ["dal", 1],
+        ["aal", 1]
+      ],
+      "type": "cyclic",
+      "offset": 0,
+      "frequency": 8,
+      "altitude":  10000
+    },
+    {
+      "_name":  "Leena 5",
+      "radial":   210,
+      "speed":    250,
+      "fixes":    ["SXC", "CWARD", "SLI"],
+      "airlines":  [
+        ["ual", 1],
+        ["baw", 1],
+        ["aca", 1]
+      ],
+      "type": "random",
+      "frequency": 6,
+      "altitude":  10000
+    },
+    {
+      "_name":  "Riivr 2",
+      "radial":   70,
+      "speed":    250,
+      "fixes":    ["RUSTT", "HABSO", "RIIVR", "BCOVE"],
+      "airlines":  [
+        ["ual", 4],
+        ["baw", 3],
+        ["dal", 2],
+        ["aca", 1]
+      ],
+      "type": "wave",
+      "offset": 5,
+      "frequency": 8,
+      "altitude":  10000
+    },
+    {
+      "_name":  "Sadde 6",
+      "radial":   330,
+      "speed":    250,
+      "fixes":    ["FIM", "SADDE", "SMO"],
+      "airlines":  [
+        ["ual", 10],
+        ["baw", 10],
+        ["fastga", 1]
+      ],
+      "type": "random",
+      "frequency": 6,
+      "altitude":  10000
+    },
+    {
+      "_name":  "Vista 2",
+      "radial":   110,
+      "speed":    250,
+      "fixes":    ["VISTA", "OCN", "SHIVE", "CWARD", "MADOW", "SLI"],
+      "airlines":  [
+        ["ual", 1],
+        ["baw", 1],
+        ["dal", 1]
+      ],
+      "type": "random",
+      "frequency": 8,
+      "altitude":  10000
+    }
+  ]
+}

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -824,7 +824,7 @@ function airport_init() {
   airport_load("ksfo");
   airport_load("kmsp");
   airport_load("kjfk");
-  // airport_load("klax");
+  airport_load("klax");
 //  airport_load("ksna");
 
   airport_load("ebbr");


### PR DESCRIPTION
Based on STARs as listed in .json. Additional fixes are also included for selected standard instrument departures.
- 34 departures/hour
- 36 arrivals/hour
