### PR TITLE
Omit unnecessary physics when not turning

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1171,7 +1171,7 @@ var Aircraft=Fiber.extend(function() {
 
         // TURNING
 
-        if(this.altitude > 10) {
+        if(this.altitude > 10 && this.heading != this.target.heading) {
           // Perform standard turns 3 deg/s or 25 deg bank, whichever
           // requires less bank angle.
           // Formula based on http://aviation.stackexchange.com/a/8013


### PR DESCRIPTION
An optimization to avoid calculation of `turn_rate`, `turn_amount` and `angle_offset` when not turning (a small help when all aircraft future tracks are being displayed).
