### PR TITLE
Small fix: correct wording to "ready for departure"

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1211,7 +1211,7 @@ var Aircraft=Fiber.extend(function() {
             (runway.isWaiting(this, this.requested.runway) == 0) &&
             (was_taxi == true))
         {
-          ui_log(this.getRadioCallsign(), "ready for takeoff runway "+radio_runway(this.requested.runway));
+          ui_log(this.getRadioCallsign(), "ready for departure runway "+radio_runway(this.requested.runway));
           this.updateStrip();
         }
       }


### PR DESCRIPTION
The term "ready for takeoff" is no longer used in ATC radio communication. It was replaced with "ready for departure" after the 1977's Tenerife airport disaster (See: https://en.wikipedia.org/wiki/Tenerife_airport_disaster#Safety_response).
To prevent confusion the term "take off" is since then used exclusively in the take of clearance.
