### PR TITLE
Add Option to make range rings user defined, per airport, via a new property in each airport.json

### DIFF
--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -5,6 +5,8 @@
   "icao": "KSFO",
   "magnetic_north": 13.7,
   "ctr_radius": 80,
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N37.6195", "W122.3738333"],
   "has_terrain": true,
   "position": ["N37.6195", "W122.3738333"],
   "wind": {

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -700,6 +700,8 @@ var Airport=Fiber.extend(function() {
       if(data.radio) this.radio = data.radio;
       if(data.ctr_radius) this.ctr_radius = data.ctr_radius;
       if(data.ctr_ceiling) this.ctr_ceiling = data.ctr_ceiling;
+      if(data.rr_radius_nm) this.rr_radius_nm = data.rr_radius_nm;
+      if(data.rr_center) this.rr_center = data.rr_center;
       if(data.level) this.level = data.level;
       this.has_terrain = false || data.has_terrain;
 

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -177,7 +177,6 @@ function canvas_draw_runway_label(cc, runway) {
   cc.translate(round(km(runway.name_offset[1][0])), -round(km(runway.name_offset[1][1])));
   cc.fillText(runway.name[1], 0, 0);
   cc.restore();
-
 }
 
 function canvas_draw_runways(cc) {
@@ -769,7 +768,6 @@ function canvas_draw_info(cc, aircraft) {
 
     cc.restore();
   }
-
 }
 
 function canvas_draw_all_info(cc) {
@@ -836,38 +834,41 @@ function canvas_draw_compass(cc) {
     cc.fillText(angle, 0, -size2+6);
     cc.restore();
   }
-
 }
 
 function canvas_draw_ctr(cc) {
   "use strict";
+  
+  //Draw a gentle fill color with border within the bounds of the airport's ctr_radius
   cc.translate(round(prop.canvas.size.width/2), round(prop.canvas.size.height/2));
   cc.translate(prop.canvas.panX, prop.canvas.panY);
   cc.fillStyle = "rgba(200, 255, 200, 0.02)";
   cc.beginPath();
   cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale, 0, Math.PI*2);
   cc.fill();
-
-  cc.beginPath();
-  cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale, 0, Math.PI*2);
+  //Draw the outline circle
+	cc.beginPath();
   cc.linewidth = 1;
-  cc.strokeStyle = "rgba(200, 255, 200, 0.25)";
-  cc.stroke();
+	cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale, 0, Math.PI*2);
+	cc.strokeStyle = "rgba(200, 255, 200, 0.25)";
+	cc.stroke();
 
-  cc.beginPath();
-  cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale*0.75, 0, Math.PI*2);
-  cc.strokeStyle = "rgba(200, 255, 200, 0.1)";
-  cc.stroke();
+  // Check if range ring characteristics are defined for this airport
+  if(airport_get().hasOwnProperty("rr_radius_nm")) {
+  	var rangeRingRadius = airport_get().rr_radius_nm *  1.852;	//convert input param from nm to km
+  }
+  else {
+  	var rangeRingRadius = airport_get().ctr_radius / 4;	//old method
+  }
 
-  cc.beginPath();
-  cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale*0.50, 0, Math.PI*2);
-  cc.strokeStyle = "rgba(200, 255, 200, 0.1)";
-  cc.stroke();
-
-  cc.beginPath();
-  cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale*0.25, 0, Math.PI*2);
-  cc.strokeStyle = "rgba(200, 255, 200, 0.1)";
-  cc.stroke();
+  //Fill up airport's ctr_radius with rings of the specified radius
+  for(var i=1; i*rangeRingRadius < airport_get().ctr_radius; i++) {
+	  cc.beginPath();
+	  cc.linewidth = 1;
+		cc.arc(0, 0, rangeRingRadius*prop.ui.scale*i, 0, Math.PI*2);
+		cc.strokeStyle = "rgba(200, 255, 200, 0.1)";
+		cc.stroke();
+  }
 }
 
 // Draw range rings for ENGM airport to assist in point merge
@@ -1000,8 +1001,8 @@ function canvas_draw_terrain(cc) {
 
     cc.restore();
   }
-
 }
+
 function canvas_draw_restricted(cc) {
   "use strict";
   if (!prop.canvas.draw_restricted) return;


### PR DESCRIPTION
First, let me say what an incredible job you all have done with this simulator! It has come along very nicely, and I've recommended it as a practice tool for many of my students (I am a Lab Instructor in a collegiate air traffic control program), as this project is in many ways just as useful as the multimillion-dollar ATC simulation software we have in our lab... So well freakin' done! I've been very impressed and would like to provide some of my own input as well, starting with the below improvement:

---

![image](https://cloud.githubusercontent.com/assets/5103735/11677422/cd39432a-9e0b-11e5-89a5-a1123a6b4004.png)
![image](https://cloud.githubusercontent.com/assets/5103735/11677663/42154dea-9e0e-11e5-9070-8e15852670b3.png)

---

As shown in the images above, range rings of a definable radius (via airport.json) can now be implemented for each airport. If the loaded airport does not have a "rr_radius_nm" property, then will use the old method of four rings within the "radius_ctr" range. In the future, I'd like to add a customizable location as well, as there are some cases where you may want to place the rings somewhere other than on the airport center.

Being from the air traffic control perspective, the first thing I noticed when playing this WONDERFUL game is that it was difficult to quickly get a sense of scale along the final approach course... in my opinion, using a standard of 5.0nm range rings would make it quite a bit easier to get a sense of scale (as that is an established standard RR radius). These changes would make the process of adding/modifying range rings both smarter and easier.

Upper: USING OLD RANGE RINGS (no change to json file)
Lower: USING 5NM RANGE RINGS (set in ksfo.json... "rr_radius_nm = 5")

Feel free to give her a test at [http://erikquinn.github.io/atc](http://erikquinn.github.io/atc), and/or hit me up with feedback.
