### PR TITLE
Realistic airspeeds

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1313,6 +1313,10 @@ var Aircraft=Fiber.extend(function() {
 
       var angle = this.heading;
       var scaleSpeed = this.speed * 0.000514444 * game_delta(); // knots to m/s
+      if (prop.game.option.get('simplifySpeeds') == 'no') {
+        // Calculate the true air speed as indicated airspeed * 1.6% per 1000'
+        scaleSpeed *= 1 + (this.altitude * 0.000016);
+      }
       this.ds = scaleSpeed;
       this.position = vsum(this.position, vscale([sin(angle), cos(angle)], scaleSpeed));
 

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -764,7 +764,11 @@ function canvas_draw_info(cc, aircraft) {
     cc.fillText(lpad(round(aircraft.altitude * 0.01), 2), -separation, line_height);
 
     cc.textAlign = "left";
-    cc.fillText(lpad(round(aircraft.speed * 0.1), 2), separation, line_height);
+    var speed = aircraft.speed;
+    if (prop.game.option.get('simplifySpeeds') == 'no') {
+        speed *= 1 + (aircraft.altitude * 0.000016);
+    }
+    cc.fillText(lpad(round(speed * 0.1), 2), separation, line_height);
 
     cc.textAlign = "center";
     cc.fillText(aircraft.getCallsign(), 0, -line_height);

--- a/assets/scripts/game.js
+++ b/assets/scripts/game.js
@@ -11,6 +11,17 @@ zlsa.atc.Options = Fiber.extend(function (base) {
                ['Selected', 'selected'],
                ['Never', 'never']]
       });
+      this.addOption({
+        name: 'simplifySpeeds',
+        defaultValue: 'yes',
+        description: 'Use simplified airspeeds',
+        help: 'Controls use of a simplified calculation which results in'
+          + ' aircraft always moving across the ground at the speed assigned.'
+          + ' In reality aircraft will move faster as they increase altitude.',
+        type: 'select',
+        data: [['Yes', 'yes'],
+               ['No', 'no']]
+      });
     },
     addOption: function(data) {
       this._options[data.name] = data;

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -74,7 +74,8 @@ function ui_init() {
   for (var key in descriptions) {
     var opt = descriptions[key];
     if (opt.type == 'select') {
-      options.append("<span class='option-description'>" +
+      var container = $('<div class="option"></div>');
+      container.append("<span class='option-description'>" +
                      opt.description + "</span>");
       var sel_span = $("<span class='option-selector option-type-select'></span>");
       var selector = $("<select id='opt-" + opt.name +
@@ -92,7 +93,8 @@ function ui_init() {
         prop.game.option.set($(this).data('name'), $(this).val());
       });
       sel_span.append(selector);
-      options.append(sel_span);
+      container.append(sel_span);
+      options.append(container);
     }
   }
 


### PR DESCRIPTION
Add an option to use simplified airspeeds.  By default it is enabled and game behavior is unaffected.

When disabled, aircraft ground speeds are affected by altitude.  The model is 1.6% increase in ground speed per 1000 feet altitude.  The speed shown in data blocks on the radar is always ground speed.

The 1.6% is based on http://williams.best.vwh.net/avform.htm#Mach with a slight increase to account for compression effects.  I didn't do the math to see how much of an effect compression would actually have at the speeds generally encountered in game.
