### PR TITLE
Include wind in aircraft movement

### DIFF
--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -764,11 +764,9 @@ function canvas_draw_info(cc, aircraft) {
     cc.fillText(lpad(round(aircraft.altitude * 0.01), 2), -separation, line_height);
 
     cc.textAlign = "left";
-    var speed = aircraft.speed;
-    if (prop.game.option.get('simplifySpeeds') == 'no') {
-        speed *= 1 + (aircraft.altitude * 0.000016);
-    }
-    cc.fillText(lpad(round(speed * 0.1), 2), separation, line_height);
+    cc.fillText(lpad(round(aircraft.groundSpeed * 0.1), 2),
+                separation,
+                line_height);
 
     cc.textAlign = "center";
     cc.fillText(aircraft.getCallsign(), 0, -line_height);


### PR DESCRIPTION
Include effect of wind on aircraft movement while simplified speeds are disabled.

As a simplification winds are assumed to increase in speed by 2% per 1000 feet.

The pilots do not compensate for wind, this means tracks to fixes will be slightly curved and the approach track will be slightly off center.  I have not tested ability to land in a high crosswind but they shouldn't be doing it anyway...
