### PR TITLE
Remove fixes after departing center - Fixes #286

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -324,6 +324,7 @@ var Aircraft=Fiber.extend(function() {
         this.requested.hold    = false;
         this.requested.altitude = 20000;
         this.requested.speed = 480;
+        this.requested.fix = [];
 
         if (this.category == "departure") {
           // Within 5 degrees of destination heading


### PR DESCRIPTION
Fixes an issue with aircraft track continuing to show a path to fixes they won't go to after leaving the center.
