### PR TITLE
Stateful violations/warnings re-factor

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -6,10 +6,47 @@ zlsa.atc.Conflict = Fiber.extend(function() {
                                  this.aircraft[1].position);
 
       this.conflicts = {};
+      this.violations = {};
 
-      this.aircraft[0].addConflict(this, aircraft[1]);
-      this.aircraft[1].addConflict(this, aircraft[0]);
+      this.aircraft[0].addConflict(this, second);
+      this.aircraft[1].addConflict(this, first);
     },
+
+    /**
+     * Is there anything which should be brought to the controllers attention
+     *
+     * @returns {Array of Boolean} First element true if any conflicts/warnings,
+     *                             Second element true if any violations.
+     */
+    hasAlerts: function() {
+      return [this.hasConflict(), this.hasViolation()];
+    },
+
+    /**
+     *  Whether any conflicts are currently active
+     */
+    hasConflict: function() {
+      for (var i in this.conflicts) {
+        if (this.conflicts[i])
+          return true;
+      }
+      return false;
+    },
+
+    /**
+     *  Whether any violations are currently active
+     */
+    hasViolation: function() {
+      for (var i in this.violations) {
+        if (this.violations[i])
+          return true;
+      }
+      return false;
+    },
+
+    /**
+     * Update conflict and violation checks, potentially removing this conflict.
+     */
     update: function() {
       this.distance = vlen(vsub(this.aircraft[0].position,
                                 this.aircraft[1].position));
@@ -19,11 +56,46 @@ zlsa.atc.Conflict = Fiber.extend(function() {
         this.remove();
         return;
       }
+
+      this.checkRunwayCollision();
     },
+
     remove: function() {
       this.aircraft[0].removeConflict(this, aircraft[1]);
       this.aircraft[1].removeConflict(this, aircraft[0]);
-    }
+    },
+
+    /**
+     * Check for a potential head-on collision on a runway
+     */
+    checkRunwayCollision: function() {
+      // Check if the aircraft are on a potential collision course
+      // on the runway
+      var airport = airport_get();
+
+      // Check for the same runway, headings differing by more
+      // than 30 degrees and under about 6 miles
+      if ((!this.aircraft[0].isTaxiing() && !this.aircraft[1].isTaxiing()) &&
+          (this.aircraft[0].requested.runway != null) &&
+          (airport.getRunway(this.aircraft[1].requested.runway) ===
+           airport.getRunway(this.aircraft[0].requested.runway)) &&
+          (abs(angle_offset(this.aircraft[0].heading, this.aircraft[1].heading)) > 0.5236) &&
+          (this.distance < 10))
+      {
+        if (!this.conflicts.runwayCollision) {
+          this.conflicts.runwayCollision = true;
+          ui_log(true, this.aircraft[0].getCallsign()
+                 + " appears on a collision course with "
+                 + this.aircraft[1].getCallsign()
+                 + " on the same runway");
+          prop.game.score.warning += 1;
+        }
+      }
+      else {
+        this.conflicts.runwayCollision = false;
+      }
+    },
+
   };
 });
 
@@ -1401,32 +1473,6 @@ var Aircraft=Fiber.extend(function() {
         // http://gamedev.stackexchange.com/questions/586/what-is-the-fastest-way-to-work-out-2d-bounding-box-intersection
         var distance = vlen(vsub(this.position, other.position));
         if(distance > 10) continue;
-        
-        // Check if the aircraft are on a potential collision course
-        // on the runway
-        if ((this.isLanded() || this.altitude < 990) &&
-            !other.isTaxiing() &&
-            (other.isLanded() || (other.altitude < 990)))
-        {
-          var airport = airport_get();
-
-          // Check for the same runway, headings differing by more
-          // than 30 degrees and under about 6 miles
-          if ((this.requested.runway != null) &&
-              (airport.getRunway(other.requested.runway) ===
-               airport.getRunway(this.requested.runway)) &&
-              (abs(angle_offset(this.heading, other.heading)) > 0.5236) &&
-              (distance < 10))
-          {
-            if (!this.warning) {
-              ui_log(true, this.getCallsign()
-                     + " appears on a collision course with " + other.getCallsign()
-                     + " on the same runway");
-              prop.game.score.warning += 1;
-            }
-            warning = true;
-          }
-        }
 
         // Ignore aircraft below about 1000 feet
         // Allows realistic departure separation via heading
@@ -1663,9 +1709,20 @@ var Aircraft=Fiber.extend(function() {
       return false;
     },
 
+    hasAlerts: function() {
+      var a = [false, false];
+      var c = null;
+      for (var i in this.conflicts) {
+        c = this.conflicts[i].hasAlerts();
+        a[0] = (a[0] || c[0]);
+        a[1] = (a[1] || c[1]);
+      }
+      return a;
+    },
+
     removeConflict: function(other) {
       delete this.conflicts[other];
-    }
+    },
   };
 });
 
@@ -1889,7 +1946,7 @@ function aircraft_update() {
       var that = prop.aircraft.list[i];
       var other = prop.aircraft.list[j];
 
-      if (that.checkViolation(other)) {
+      if (that.checkConflict(other)) {
         continue;
       }
 
@@ -1897,8 +1954,8 @@ function aircraft_update() {
       // no violation can occur in this case.
       // Variation of:
       // http://gamedev.stackexchange.com/questions/586/what-is-the-fastest-way-to-work-out-2d-bounding-box-intersection
-      var dx = Math.abs(this.position[0] - other.position[0]);
-      var dy = Math.abs(this.position[1] - other.position[1]);
+      var dx = Math.abs(that.position[0] - other.position[0]);
+      var dy = Math.abs(that.position[1] - other.position[1]);
       if ((dx > 10) || (dy > 10)) {
         continue;
       }

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -400,13 +400,15 @@ function canvas_draw_aircraft(cc, aircraft) {
     canvas_draw_future_track(cc, aircraft);
   }
 
+  var alerts = aircraft.hasAlerts();
+
   if (!aircraft.inside_ctr)
     cc.fillStyle   = "rgba(224, 224, 224, 0.3)";
   else if (almost_match)
     cc.fillStyle = "rgba(224, 210, 180, 1.0)";
   else if (match)
     cc.fillStyle = "rgba(255, 255, 255, 1.0)";
-  else if (aircraft.warning)
+  else if (aircraft.warning || alerts[1])
     cc.fillStyle = "rgba(224, 128, 128, 1.0)";
   else if (aircraft.hit)
     cc.fillStyle = "rgba(255, 64, 64, 1.0)";
@@ -453,7 +455,7 @@ function canvas_draw_aircraft(cc, aircraft) {
     cc.restore();
   }
 
-  if(aircraft.notice) {
+  if(aircraft.notice || alerts[0]) {
     cc.save();
     cc.strokeStyle = cc.fillStyle;
     cc.beginPath();


### PR DESCRIPTION
The notice/warning system is unable to generate more than one notice for a given aircraft.  It is also difficult to extend the existing system to deal with closing rate based alerts.

This creates a conflict object for any pair of aircraft which are within a 10km box from each other.  Checks can than be carried out on the pair with consistent pairwise state over time.

Specific things which this will allow are:
- Suppressing alerts for parallel takeoffs when headings differ and separation is increasing
- Suppressing alerts for crossing traffic at 1000 foot intervals which are stable in altitude
- Applying in-trail alerts for landing aircraft on the same runway
