### PR TITLE
Remove 1500 foot vertical separation notices

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -136,6 +136,13 @@ zlsa.atc.Conflict = Fiber.extend(function() {
      * Check for physical proximity and trigger crashes if necessary
      */
     checkProximity: function() {
+      // No conflict or warning if vertical separation is present
+      if (this.altitude >= 1000) {
+        this.conflicts.proximityConflict = false;
+        this.conflicts.proximityViolation = false;
+        return;
+      }
+
       var conflict = false;
       var violation = false;
 
@@ -146,31 +153,19 @@ zlsa.atc.Conflict = Fiber.extend(function() {
       {
         if (this.aircraft[0].requested.runway != this.aircraft[1].requested.runway)
         {
-          // Notice at 3500 feet horizontal and 1500 feet vertical
-          if ((this.distance < 1.067) && (this.altitude < 1500))
-            conflict = true;
-          // Warning at 3000 feet and 1000 feet vertical
-          if ((this.distance < 0.914) && (this.altitude < 1000))
-            violation = true;
+          conflict = (this.distance < 1.067); // 3500 feet
+          violation = (this.distance < 0.914); // 3000 feet
         }
         else
         {
-          // Notice at 2.8nm horizontal and 1500 feet vertical
-          if ((this.distance < 5.2) && (this.altitude < 1500))
-            conflict = true;
-          // Warning within 2.5nm horizontal and 1000 feet vertical
-          if ((this.distance < 4.6) && (this.altitude < 1000))
-            violation = true;
+          conflict = (this.distance < 5.2); // 2.8nm
+          violation = (this.distance < 4.6); // 2.5nm
         }
       }
       // Standard separation
       else {
-        // Notice at 4nm horizontal and 1500 feet vertical
-        if ((this.distance < 7.4) && (this.altitude < 1500))
-          conflict = true;
-        // Violation within 3nm horizontal and 1000 feet vertical
-        if ((this.distance < 5.6) && (this.altitude < 1000))
-          violation = true;
+        conflict = (this.distance < 7.4); // 4nm
+        violation = (this.distance < 5.6); // 3nm
       }
 
       if (conflict)

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -1,0 +1,39 @@
+---
+title: Aircraft Separation rules
+---
+[back to index](index.html)
+
+# Aircraft separation
+
+## General Separation
+
+While in flight if there is not a more specific rule which applies
+then aircraft must be separated by at least 3nm laterally or 1000 feet
+vertically.
+
+A notice will occur for aircraft which are within 4nm laterally
+and 1500 feet vertically.
+
+Collisions occur when an aircraft is within approximately 160 feet of
+another aircraft.
+
+## Head-on use of runway
+
+A warning will be issued if two aircraft within 6 miles of each other
+are assigned to the same runway but have opposite headings.
+
+## Reduced lateral separation during runway approach
+
+Standard vertical separation may be applied if the specified lateral
+separation can't be guaranteed.
+
+### Same runway
+
+Two aircraft which have both captured the runway localizer must remain
+at least 2.5nm from each other.  A notice occurs at 2.8nm.
+
+### Different runways
+
+Two aircraft which have both captured the localizer of their
+respective runway must remain 3000 feet apart, a notice will occur at
+3500 feet.

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -11,8 +11,8 @@ While in flight if there is not a more specific rule which applies
 then aircraft must be separated by at least 3nm laterally or 1000 feet
 vertically.
 
-A notice will occur for aircraft which are within 4nm laterally
-and 1500 feet vertically.
+A notice will occur for aircraft which do not have sufficient vertical
+separation and are within 4nm laterally.
 
 Collisions occur when an aircraft is within approximately 160 feet of
 another aircraft.
@@ -25,7 +25,7 @@ are assigned to the same runway but have opposite headings.
 ## Reduced lateral separation during runway approach
 
 Standard vertical separation may be applied if the specified lateral
-separation can't be guaranteed.
+separation isn't maintained.
 
 ### Same runway
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -7,6 +7,7 @@ title: Index
 ## Pages
 
 * [Airport format](airport-format.html)
+* [Aircraft separation](aircraft-separation.html)
 * [Scoring](scoring.html)
 * [Documentation format](README.html)
 

--- a/documentation/scoring.md
+++ b/documentation/scoring.md
@@ -31,8 +31,12 @@ You lose 20 points for every arriving aircraft that leaves the area
 (and therefore hadn't landed).
 
 ## Warning
-Every time two aircraft come within 3 miles and 1000 feet of vertical
-separation, 5 points are lost.
+Any time a warning is issued for an aircraft 5 points are lost.  The
+most common warning is when two aircraft are separated by less 3
+nautical miles or less than 1000 feet of altitude.  However there are
+a number of situations where aircraft can be separated by less, for
+complete details refer to the
+[aircraft separation rules](aircraft-separation.html)
 
 ## Collisions
 50 points are lost whenever two aircraft collide (within 50 or so feet


### PR DESCRIPTION
Remove the notices for lateral separation when sufficient vertical separation is in place.

The primary drawback to this is that there is no warning prior to a violation occurring due to altitude changes.
