### PR TITLE
Reduce lateral separation on a per run-way basis - Fixes #261

### DIFF
--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -72,6 +72,7 @@
       "oldposition":  [0, 0.229],
       "end":    [ ["N37.6135324", "W122.3571410"], ["N37.6287386", "W122.3933911"]],
       "length":      3.62,
+      "lateral_separaton": 300,
       "ils":         [true, false]
     },
     {
@@ -80,6 +81,8 @@
       "oldposition":    [0, 0],
       "end":    [["N37.6117091", "W122.3583420"], ["N37.6262900", "W122.3931054"]],
       "length":      3.47,
+      "_note": "Lateral separation simulates visual approaches",
+      "lateral_separaton": 600,
       "ils":         [true, false]
     },
     {

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -547,7 +547,7 @@ var Runway=Fiber.extend(function(base) {
       this.ils          = [false, false];
       this.ils_distance = [null, null];
       this.delay        = [2, 2];
-
+      this.lateral_separation = 4300 * 0.0003048;
       this.waiting      = [[], []];
 
       this.parse(options);
@@ -660,6 +660,9 @@ var Runway=Fiber.extend(function(base) {
       if(data.ils_distance) this.ils_distance = data.ils_distance;
 
       if(data.delay) this.delay = data.delay;
+
+      if (data.lateral_separation)
+        this.lateral_separation = data.lateral_separation * 0.0003048;
     },
   };
 });

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -27,13 +27,19 @@ are assigned to the same runway but have opposite headings.
 Standard vertical separation may be applied if the specified lateral
 separation isn't maintained.
 
+Aircraft are considered established when they are laterally within 160
+feet of the approach centerline.
+
 ### Same runway
 
-Two aircraft which have both captured the runway localizer must remain
+Two aircraft which have both captured the same runway localizer must remain
 at least 2.5nm from each other.  A notice occurs at 2.8nm.
 
 ### Different runways
 
-Two aircraft which have both captured the localizer of their
-respective runway must remain 3000 feet apart, a notice will occur at
-3500 feet.
+The separation distance between two aircraft may be set on a runway by
+runway basis.  Typically two aircraft may approach no closer than
+4,300 to 3,000 feet laterally while both are established on the
+approach.  In some cases the minimum separation may be higher such as
+a simultaneous close parallel approach where it will be 9114 feet (1.5
+nautical miles).

--- a/documentation/airport-format.md
+++ b/documentation/airport-format.md
@@ -35,6 +35,7 @@ airport code, such as `ksfo` or `kmsp`.
       "angle":       0,                // the heading of the first end of the runway ("36" in this case)
       "length":      3,                // the length of the runway, in km
       "delay":       [2, 2],           // the number of seconds it takes to taxi to the end of the runway
+      "lateral_separation": 3000,      // Distance in feet that another aircraft can come while on parallel approach paths, a violation will occur at 85% of this value
       "ils":         [true, false]     // not used yet; indicates whether or not that end of the runway has ILS
     }
   ],


### PR DESCRIPTION
Allows setting approach lateral separation on a per runway basis.

@glangford, I've set KSFO to a 600' lateral separation between 28r/28l as a visual approach simulation.  The alternative is a 9114' separation for SCP approaches.
