### PR TITLE
Add 5nm range rings (follow-up to #281) and improve airport selection dialog

### DIFF
--- a/assets/airports/ebbr.json
+++ b/assets/airports/ebbr.json
@@ -1,11 +1,16 @@
 {
+  "reference": "https://www.belgocontrol.be/opersite/eaip/eAIP_Main/html/eAIP/EB-AD-2.EBBR-en-GB.html",
   "name": "Brussels-National",
   "level": "easy",
   "radio": "Brussels",
   "icao": "EBBR",
   "iata": "BRU",
-  "eiap": "http://www.belgocontrol.be/website/eaip/eAIP_Main/html/eAIP/EB-AD-2.EBBR-en-GB.html",
+  "magnetic_north": 0,
   "ctr_radius": 80,
+  "position": ["N0.0", "W0.0"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N0.0", "W0.0"],
+  "has_terrain": false,
   "wind": {
     "angle": 230,
     "speed": 6

--- a/assets/airports/eddh.json
+++ b/assets/airports/eddh.json
@@ -3,8 +3,13 @@
   "level": "easy",
   "radio": "Hamburg",
   "icao": "EDDH",
+  "iata": "HAM",
+  "magnetic_north": 0,
   "ctr_radius": 80,
   "position": ["N53d37m49.00", "E9d59m18.00"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N53d37m49.00", "E9d59m18.00"],
+  "has_terrain": false,
   "wind": {
     "angle": 230,
     "speed": 6

--- a/assets/airports/eddm.json
+++ b/assets/airports/eddm.json
@@ -1,11 +1,15 @@
 {
-  "name": "Franz Josef Strauß International Airport",
+  "name": "Franz Josef Strauß International Airport &#9983",
   "level": "beginner",
   "radio": "Munich",
   "icao": "EDDM",
   "iata": "MUC",
+  "magnetic_north": 0,
   "ctr_radius": 80,
 	"position": ["N48.353803", "E11.786100"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N48.353803", "E11.786100"],
+  "has_terrain": false,
   "wind": {
     "angle": 273,
     "speed": 3 

--- a/assets/airports/eglc.json
+++ b/assets/airports/eglc.json
@@ -4,8 +4,12 @@
   "radio": "City",
   "icao": "EGLC",
   "iata": "LCY",
+  "magnetic_north": 0,
   "ctr_radius": 80,
   "position": ["N51d30m19.08", "E0d3m19.00"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N51d30m19.08", "E0d3m19.00"],
+  "has_terrain": false,
   "wind": {
     "angle": 275,
     "speed": 6

--- a/assets/airports/eham.json
+++ b/assets/airports/eham.json
@@ -4,8 +4,12 @@
   "radio": "Amsterdam",
   "icao": "EHAM",
   "iata": "AMS",
+  "magnetic_north": 0,
   "ctr_radius": 80,
-   "position": ["N52d18m30.96", "E004d45m51.00"],
+  "position": ["N52d18m30.96", "E004d45m51.00"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N52d18m30.96", "E004d45m51.00"],
+  "has_terrain": false,
   "wind": {
     "angle": 230,
     "speed": 6

--- a/assets/airports/eidw.json
+++ b/assets/airports/eidw.json
@@ -1,9 +1,15 @@
-{ "name": "Dublin Airport",
+{
+  "name": "Dublin Airport",
   "level": "easy",
   "radio": "Dublin",
   "icao": "EIDW",
+  "iata": "DUB",
+  "magnetic_north": 0,
   "ctr_radius": 80,
   "position": ["N53d25m17.00", "W6d16m12.00"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N53d25m17.00", "W6d16m12.00"],
+  "has_terrain": false,
   "wind": {
     "angle": 120,
     "speed": 8

--- a/assets/airports/engm.json
+++ b/assets/airports/engm.json
@@ -1,11 +1,15 @@
 {
-  "name": "Oslo Gardermoen International Airport (WIP)",
+  "name": "Oslo Gardermoen International Airport &#9983",
   "level": "easy",
   "radio": "Oslo",
   "icao": "ENGM",
+  "iata": "OSL",
   "magnetic_north": -2.8,
   "ctr_radius": 80,
   "position": ["N60d12m10.00", "E11d05m02.00"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N60d12m10.00", "E11d05m02.00"],
+  "has_terrain": false,
   "wind": {
     "angle": 190,
     "speed": 8

--- a/assets/airports/kdbg.json
+++ b/assets/airports/kdbg.json
@@ -3,7 +3,13 @@
   "level": "medium",
   "radio": "Debug",
   "icao": "KDBG",
+  "iata": "DBG",
+  "magnetic_north": 0,
   "ctr_radius": 80,
+  "position": ["N0.0", "W0.0"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N0.0", "W0.0"],
+  "has_terrain": false,
   "wind": {
     "angle": 0,
     "speed": 8

--- a/assets/airports/kjfk.json
+++ b/assets/airports/kjfk.json
@@ -1,10 +1,15 @@
 {
-  "name": "John F Kennedy International Airport (WIP)",
+  "name": "John F Kennedy International Airport &#9983",
   "level": "medium",
   "radio": "Kennedy",
   "icao": "KJFK",
+  "iata": "JFK",
+  "magnetic_north": 0,
   "ctr_radius": 80,
   "position": ["N40.6328889", "W73.7713889"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N40.6328889", "W73.7713889"],
+  "has_terrain": false,
   "wind": {
     "angle": 180,
     "speed": 6

--- a/assets/airports/klax.json
+++ b/assets/airports/klax.json
@@ -3,9 +3,13 @@
   "level": "medium",
   "radio": "Los Angeles",
   "icao": "KLAX",
+  "iata": "LAX",
   "magnetic_north": 12.3,
   "ctr_radius": 80,
-  "position": ["N33d56m33.13", "W118d24m29.07" ],
+  "position": ["N33d56m33.13", "W118d24m29.07"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N33d56m33.13", "W118d24m29.07"],
+  "has_terrain": false,
   "wind": {
     "angle": 260,
     "speed": 10

--- a/assets/airports/kmsp.json
+++ b/assets/airports/kmsp.json
@@ -1,11 +1,15 @@
 {
-  "name": "Minneapolis/St. Paul International Airport (WIP)",
+  "name": "Minneapolis/St. Paul International Airport &#9983",
   "level": "hard",
   "radio": "Minneapolis",
   "icao": "KMSP",
+  "iata": "MSP",
   "magnetic_north": 0.4,
-  "position": ["N44.884188", "W93.215083"],
   "ctr_radius": 80,
+  "position": ["N44.884188", "W93.215083"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N44.884188", "W93.215083"],
+  "has_terrain": false,
   "wind": {
     "angle": 300,
     "speed": 8

--- a/assets/airports/ksan.json
+++ b/assets/airports/ksan.json
@@ -3,10 +3,13 @@
   "level": "easy",
   "radio": "San Diego",
   "icao": "KSAN",
-  "ctr_radius": 80,
-  "rr_radius_nm": 5.0,
-  "position": ["N32.734", "W117.190", "5m"],
+  "iata": "SAN",
   "magnetic_north": 12.3,
+  "ctr_radius": 80,
+  "position": ["N32.734", "W117.190", "5m"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N32.734", "W117.190"],
+  "has_terrain": false,
   "wind": {
     "angle": 300,
     "speed": 8

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -1,14 +1,15 @@
 {
-  "name": "San Francisco International Airport (WIP)",
+  "name": "San Francisco International Airport &#9983",
   "level": "medium",
   "radio": "San Francisco",
   "icao": "KSFO",
+  "iata": "SFO",
   "magnetic_north": 13.7,
   "ctr_radius": 80,
+  "position": ["N37.6195", "W122.3738333"],
   "rr_radius_nm": 5.0,
   "rr_center": ["N37.6195", "W122.3738333"],
   "has_terrain": true,
-  "position": ["N37.6195", "W122.3738333"],
   "wind": {
     "angle": 310,
     "speed": 5

--- a/assets/airports/ltba.json
+++ b/assets/airports/ltba.json
@@ -1,11 +1,15 @@
 {
-  "name": "Atatürk International Airport  (WIP)",
+  "name": "Atatürk International Airport &#9983",
   "level": "hard",
   "radio": "Istanbul",
   "icao": "LTBA",
+  "iata": "IST",
   "magnetic_north": 3.6,
-  "position": ["N40.976898", "E28.814600"],
   "ctr_radius": 80,
+  "position": ["N40.976898", "E28.814600"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N40.976898", "E28.814600"],
+  "has_terrain": false,
   "wind": {
     "angle": 25,
     "speed": 6

--- a/assets/airports/saez.json
+++ b/assets/airports/saez.json
@@ -1,10 +1,15 @@
-{ "name": "Aeropuerto Internacional Ministro Pistarini",
+{
+  "name": "Aeropuerto Internacional Ministro Pistarini",
   "level": "medium",
   "radio": "Ezeiza",
   "icao": "SAEZ",
   "iata": "EZE",
+  "magnetic_north": 0,
   "ctr_radius": 102,
   "position": ["S34d49m19.92", "W58d32m8.8"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["S34d49m19.92", "W58d32m8.8"],
+  "has_terrain": false,
   "wind": {
     "angle": 109,
     "speed": 6

--- a/assets/airports/sbgl.json
+++ b/assets/airports/sbgl.json
@@ -4,8 +4,11 @@
   "radio": "Galeão",
   "icao": "SBGL",
   "iata": "GIG",
+  "magnetic_north": 0,
   "ctr_radius": 115,
   "position": ["S22.813391", "W43.249464"],
+  "rr_radius_nm": 5.0,
+  "rr_center": ["S22.813391", "W43.249464"],
   "has_terrain": true,
   "wind": {
     "angle": 150,

--- a/assets/airports/sbgr.json
+++ b/assets/airports/sbgr.json
@@ -4,9 +4,12 @@
   "radio": "Guarulhos",
   "icao": "SBGR",
   "iata": "GRU",
+  "magnetic_north": 0,
   "ctr_radius": 80,
   "position": ["S23.253020", "W46.265706"],
-
+  "rr_radius_nm": 5.0,
+  "rr_center": ["S23.253020", "W46.265706"],
+  "has_terrain": false,
   "wind": {
     "angle": 50,
     "speed": 10

--- a/assets/airports/uudd.json
+++ b/assets/airports/uudd.json
@@ -3,10 +3,13 @@
   "level": "easy",
   "radio": "Domodedovo",
   "icao": "UUDD",
-  "ctr_radius": 70,
+  "iata": "DME",
   "magnetic_north": 10.8, 
+  "ctr_radius": 70,
   "position": ["N55.408611", "E37.906389"],
-
+  "rr_radius_nm": 5.0,
+  "rr_center": ["N55.408611", "E37.906389"],
+  "has_terrain": false,
   "wind": {
     "angle": 2,
     "speed": 5

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -138,7 +138,7 @@ function ui_complete() {
     }
 
     var html = $("<li class='airport icao-"+airport.icao.toLowerCase()+"'>" +
-                 "<span class='difficulty'>" + difficulty + "</span>" +
+                 "<span style='font-size: 7pt' class='difficulty'>" + difficulty + "</span>" +
                  "<span class='icao'>" + airport.icao + "</span>" +
                  "<span class='name'>" + airport.name + "</span></li>");
 
@@ -149,9 +149,12 @@ function ui_complete() {
       }
     });
 
-    $("#airport-switch .list").append(html);
-
+    $("#airport-list").append(html);
   }
+  var symbol = $("<span class='symbol'>" + "&#9983" + "</span>");
+  $("#airport-list-notes").append(symbol);
+  var notes = $("<span class='words'>" + "indicates airport is a work in progress" + "</span>");
+  $("#airport-list-notes").append(notes);
 }
 
 function pixels_to_km(pixels) {

--- a/assets/style/airport.css
+++ b/assets/style/airport.css
@@ -1,53 +1,78 @@
-
 #airport-switch {
   position: absolute;
-  top: 10%;
-  bottom: 10%;
+  top: 0;
+  bottom: 0;
   left: 0;
   right: 0;
   opacity: 0;
   pointer-events: none;
+  background-color: rgba(15, 25, 20, 1);
+  border: 6px solid rgba(31, 65, 48, 1.0);
+  box-shadow: 0 0 50px -10px rgba(0,0,0,.3);
+  border-radius: 8px;
+  color: #ddd;
+  font-size: 12px;
+  padding: 0px 10px 0px 10px;
+  margin: auto;
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+  max-height: calc(85% - 2.3em - 20px);
+  overflow-y: auto;
   transition: opacity 0.5s ease;
 }
+
 #airport-switch.open {
   pointer-events: auto;
   opacity: 1;
 }
 
-#airport-switch > div {
+#airport-list {
   background-color: rgba(15, 25, 20, 1);
-  border: 6px solid rgba(31, 65, 48, 1.0);
-  box-shadow: 0 0 50px -10px rgba(0,0,0,.3);
-  border-radius: 6px;
+  /*border: 2px solid rgba(31, 65, 48, 1.0);*/
+  border: 2px solid rgba(31, 65, 48, 1.0);
+  /*box-shadow: 0 0 50px -10px rgba(0,0,0,.3);*/
+  border-radius: 10px;
   color: #ddd;
-  font-size: 12px;
-  padding: 12px 15px;
+  font-size: 100%;
+  padding: 5px 5px;
+  /*margin: 0 0 3px 0;*/
   margin: 0 auto;
-  width: 90%;
+  width: 100%;
   max-width: 500px;
-  height: 100%;
+  height: auto;
+  max-height: calc(100% - 2.3em - 30px);
   overflow-y: auto;
 }
 
 #airport-switch li {
   list-style-type: none;
-
-  padding: 5px 10px;
+  padding: 8px 10px;
+  /*padding: 5px 10px;*/
+  /*padding: 0;*/
   margin-bottom: 2px;
 }
 
 #airport-switch li .difficulty {
   display: inline-block;
-  width: 3.5em;
+  width: 5em;
   font-weight: bold;
   font-size: 120%;
   margin-right: 0.25em;
-  text-align: center;
+  text-align: right;
+  white-space: nowrap;
 }
 
 #airport-switch li .icao {
   display: inline-block;
-  width: 7em;
+  width: 4em;
+  /*margin-right: */
+  text-align: center;
+  font-weight: bold;
+}
+
+#airport-switch li .name {
+  display: inline-block;
   font-weight: bold;
 }
 
@@ -65,3 +90,22 @@
   cursor: auto;
 }
 
+#airport-list-notes {
+  font-size: 70%;
+  font-weight: normal;
+  padding: 2px 0px 3px 0px;
+  min-height: 0.8em;
+}
+
+#airport-list-notes .symbol {
+  display: inline-block;
+  text-align: "center";
+  font-style: normal;
+}
+
+#airport-list-notes .words {
+  display: inline-block;
+  text-align: "center";
+  font-style: italic;
+  padding-left: 0.5em;
+}

--- a/index.html
+++ b/index.html
@@ -54,10 +54,9 @@
       </span>
     </div>
     <div id="airport-switch">
-      <div class='nice-scrollbar'>
-        <ul class="list">
-        </ul>
-      </div>
+      <p align="center" style="font-size: 170%; padding: 10px 0px 7px 0px; min-height: 1.5em">Select Airport</p>
+      <div id="airport-list" class="nice-scrollbar"></div>
+      <p id="airport-list-notes" align="center"></p>
     </div>
     <div id="paused">
       <img src="assets/images/paused-overlay.png" title="Resume simulation" />


### PR DESCRIPTION
Follow-up to #281. This adds 5nm range rings to all airports by default. I know that's the established standard in FAA ATC, but it may not be the case in other countries... I just set them all to 5nm because that sounds better than "one-fourth of whatever the airport 'center radius' is", which is what it does if no "rr_radius" is defined. Also fills out all of the properties that may or may not have been defined in some airport.json files... eg ("has_terrain = false") for airports that don't have terrain, instead of saying nothing.

Also made some changes to clean up the airport selection dialog. See below screenshot on that. _These changes depend on #320._

Dialog may be tested at [http://erikquinn.github.io/atc/](http://erikquinn.github.io/atc/).

---

![image](https://cloud.githubusercontent.com/assets/5103735/12106072/72f3bd68-b329-11e5-9e83-89afed5c3729.png)
