### PR TITLE
Fix bug with font selection

### DIFF
--- a/assets/style/font.css
+++ b/assets/style/font.css
@@ -1,14 +1,13 @@
+/*Fallback font for broader unicode char coverage.*/
+/*source: http://www.fontspace.com/unicode-fonts-for-ancient-scripts/symbola*/
+@font-face {
+  font-family: 'monoOne';
+  src: url('../fonts/Symbola.ttf') format('truetype');
+}
+
 /*Primary Font*/
 @font-face {
   font-family: 'monoOne';
   src: url('../fonts/monoOne.otf') format('otf'),
        url('../fonts/monoOne.woff') format('woff');
-}
-
-/*Additional font for broader unicode coverage*/
-/* source: http://www.fontspace.com/unicode-fonts-for-ancient-scripts/symbola */
-@font-face {
-  font-family: 'monoOne';
-  src: url('../fonts/Symbola.ttf') format('truetype');
-  unicode-range: U+2B00-2BFF;	/*include only arrow characters*/
 }


### PR DESCRIPTION
Related to changes in #311.

Fixes bug where Firefox was not assigning the right font priority because it apparently doesn't listen to 'unicode-range=xxx:xxx' like other browsers. I found that simply changing the _order_ of the fonts in 'font.css' resolved the issue, thus making 'monoOne' the primary and 'Symbola' the fallback instead of using 'unicode-range'. Thanks to @harp71 for pointing it out.
