### PR TITLE
Implement diverging separation rules

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -182,9 +182,10 @@ zlsa.atc.Conflict = Fiber.extend(function() {
       else {
         var offset = abs(angle_offset(this.aircraft[0].groundTrack,
                                       this.aircraft[1].groundTrack));
-        //TODO: Opposing course doesn't seem to be handled correctly
-        // Check for courses differing by at least 15 degrees and within 4nm
-        if ((this.distance <= 7.4) && (offset > radians(15)))
+
+        // Check for diverging separation based on heading difference
+        // and being close enough that it may apply.
+        if ((this.distance <= 7.4) && (offset >= radians(15)))
         {
           // Opposing courses simply check the distance is increasing
           if (offset > radians(165)) {

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -17,6 +17,14 @@ separation and are within 4nm laterally.
 Collisions occur when an aircraft is within approximately 160 feet of
 another aircraft.
 
+## Diverging courses
+
+Aircraft may approach closer if they are on courses which differ by at
+least 15 degrees and one aircraft has passed the point where the
+courses intersect.  If the headings differ by more than 165 degrees,
+then the aircraft may approach closer once the distance between them
+is increasing.
+
 ## Head-on use of runway
 
 A warning will be issued if two aircraft within 6 miles of each other


### PR DESCRIPTION
Maintain separation when aircraft are on diverging flight paths of at least 15 degrees difference and one aircraft has passed the projected course of the other.
