### PR TITLE
Give 1 minute grace period for aircraft after takeoff

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -75,6 +75,12 @@ zlsa.atc.Conflict = Fiber.extend(function() {
           (this.aircraft[1].altitude < 990))
         return;
 
+      // Ignore aircraft in the first minute of their flight
+      if ((game_time() - this.aircraft[0].takeoffTime < 60) ||
+          (game_time() - this.aircraft[0].takeoffTime < 60)) {
+        return;
+      }
+
       this.checkProximity();
     },
 
@@ -458,6 +464,8 @@ var Aircraft=Fiber.extend(function() {
       this.groundTrack = 0;
       this.ds          = 0;
 
+      this.takeoffTime = 0;
+
       // Distance laterally from the approach path
       this.approachOffset = 0;
       // Distance longitudinally from the threshold
@@ -583,9 +591,11 @@ var Aircraft=Fiber.extend(function() {
       this.html.find(".aircraft").prop("title", this.model.name);
 
       if(this.category == "arrival") {
+        this.takeoffTime = game_time();
         this.html.addClass("arrival");
         this.html.prop("title", "Scheduled for arrival");
       } else {
+        this.takeoffTime = null;
         this.html.addClass("departure");
         this.html.prop("title", "Scheduled for departure");
       }
@@ -1275,6 +1285,7 @@ var Aircraft=Fiber.extend(function() {
       if(runway.removeQueue(this, this.fms.currentWaypoint().runway)) {
         this.mode = "takeoff";
         prop.game.score.windy_takeoff += this.scoreWind('taking off');
+        this.takeoffTime = game_time();
 
         if(this.fms.currentWaypoint().heading == null)
           this.fms.setCurrent({heading: runway.getAngle(this.fms.currentWaypoint().runway)});

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -9,7 +9,8 @@ title: Aircraft Separation rules
 
 While in flight if there is not a more specific rule which applies
 then aircraft must be separated by at least 3nm laterally or 1000 feet
-vertically.
+vertically.  No separation incidents are registered for aircraft in
+their first minute of flight.
 
 A notice will occur for aircraft which do not have sufficient vertical
 separation and are within 4nm laterally.


### PR DESCRIPTION
As the title says.  For 1 minute after giving the takeoff order aircraft aren't checked for proximity separation issues.

@erikquinn, should it be 1 minute from rotation or is 1 minute from the takeoff good enough?
