### PR TITLE
"*" Not working as a landing command, changed text accordingly

### DIFF
--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -261,7 +261,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 1",
-    text:     ["You can clear aircraft for an ILS approach with the "ILS" command, followed by a runway name. Before you can do so, however,",
+    text:     ["You can clear aircraft for an ILS approach with the &quot;ILS&quot; command, followed by a runway name. Before you can do so, however,",
                "it must be on a heading that will cross the runway's extended centerline, that is no more than 30 degrees offset from the",
                "runway's heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS's localizer",
                "once they're within a few degrees of the extended centerline."

--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -261,7 +261,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 1",
-    text:     ["You can clear aircraft for an ILS approach with the "Land" command, followed by a runway name. Before you can do so, however,",
+    text:     ["You can clear aircraft for an ILS approach with the "ILS" command, followed by a runway name. Before you can do so, however,",
                "it must be on a heading that will cross the runway's extended centerline, that is no more than 30 degrees offset from the",
                "runway's heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS's localizer",
                "once they're within a few degrees of the extended centerline."
@@ -275,7 +275,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 2",
-    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;l &lt;runway&gt;&rsquo;",
+    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;i &lt;runway&gt;&rsquo;",
                "with the runway that&rsquo;s in front of it. Once it's close enough to capture the localizer, the assigned altitude on its strip",
                "will change to &lsquo;ILS locked&rsquo; (meaning the aircraft is capable of guiding itself down to the runway via",
                "the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance."

--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -275,7 +275,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 2",
-    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;l&lt;runway&gt;&rsquo;",
+    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;l &lt;runway&gt;&rsquo;",
                "with the runway that&rsquo;s in front of it. Once it's close enough to capture the localizer, the assigned altitude on its strip",
                "will change to &lsquo;ILS locked&rsquo; (meaning the aircraft is capable of guiding itself down to the runway via",
                "the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance."

--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -261,7 +261,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 1",
-    text:     ["You can clear aircraft for an ILS approach with the asterisk (*) key, followed by a runway name. Before you can do so, however,",
+    text:     ["You can clear aircraft for an ILS approach with the "Land" command, followed by a runway name. Before you can do so, however,",
                "it must be on a heading that will cross the runway's extended centerline, that is no more than 30 degrees offset from the",
                "runway's heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS's localizer",
                "once they're within a few degrees of the extended centerline."
@@ -275,7 +275,7 @@ function tutorial_init_pre() {
 
   tutorial_step({
     title:    "Approach Clearances, part 2",
-    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;*&lt;runway&gt;&rsquo;",
+    text:     ["When you have the aircraft facing the right direction, just select it and type &lsquo;l&lt;runway&gt;&rsquo;",
                "with the runway that&rsquo;s in front of it. Once it's close enough to capture the localizer, the assigned altitude on its strip",
                "will change to &lsquo;ILS locked&rsquo; (meaning the aircraft is capable of guiding itself down to the runway via",
                "the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance."
@@ -292,7 +292,7 @@ function tutorial_init_pre() {
     text:     ["You may choose to enter one command at a time, but air traffic controllers usually do multiple. Particularly in approach clearances,",
                "they follow an acronym &ldquo;PTAC&rdquo; for the four elements of an approach clearance, the &lsquo;T&rsquo; and &lsquo;C&rsquo; of which",
                "stand for &lsquo;Turn&rsquo; and &lsquo;Clearance&rsquo;, both of which we entered separately in this tutorial. Though longer, it is both ",
-               "easier and more real-world accurate to enter them together, like this: &lsquo;fh250 *28r&rsquo;."
+               "easier and more real-world accurate to enter them together, like this: &lsquo;fh250 l28r&rsquo;."
                ].join(" "),
     parse:    function(t) {
       return t.replace("{CALLSIGN}", prop.aircraft.list[0].getCallsign());


### PR DESCRIPTION
Hope I got this all right... Issue #330 brought to attention that the "*" command is not a valid command for the ILS approach. I changed the tutorial to show both the "Land" command and its abbreviation, "l" to use for getting an aircraft locked on the ILS.
