### PR TITLE
Prep for #326: Add more aircraft categorizations/characteristics

### DIFF
--- a/assets/aircraft/a124.json
+++ b/assets/aircraft/a124.json
@@ -1,9 +1,17 @@
 {
   "name": "Antonov 124 Ruslan",
   "icao": "A124",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.7,
     "ascent":     1000,
     "descent":    2000,
     "accelerate": 4,

--- a/assets/aircraft/a306.json
+++ b/assets/aircraft/a306.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A300-600",
   "icao": "A306",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1800,
     "descent":    2100,
     "accelerate": 8,

--- a/assets/aircraft/a318.json
+++ b/assets/aircraft/a318.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A318",
   "icao": "A318",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.5,
     "ascent":     1900,
     "descent":    2100,
     "accelerate": 7,

--- a/assets/aircraft/a319.json
+++ b/assets/aircraft/a319.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A319",
   "icao": "A319",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.4,
     "ascent":     1600,
     "descent":    1800,
     "accelerate": 6.5,

--- a/assets/aircraft/a320.json
+++ b/assets/aircraft/a320.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A320",
   "icao": "A320",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.3,
     "ascent":     1800,
     "descent":    2000,
     "accelerate": 7,

--- a/assets/aircraft/a321.json
+++ b/assets/aircraft/a321.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A321",
   "icao": "A321",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1800,
     "descent":    2000,
     "accelerate": 6,

--- a/assets/aircraft/a332.json
+++ b/assets/aircraft/a332.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A330-200",
   "icao": "A332",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 8,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 6,

--- a/assets/aircraft/a333.json
+++ b/assets/aircraft/a333.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A330-300",
   "icao": "A333",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 8,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 6,

--- a/assets/aircraft/a343.json
+++ b/assets/aircraft/a343.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A340-300",
   "icao": "A343",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.7,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 4,

--- a/assets/aircraft/a346.json
+++ b/assets/aircraft/a346.json
@@ -1,7 +1,16 @@
 {
   "name": "Airbus A340-600",
   "icao": "A346",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
     "turn":       0.8,
     "ascent":     1400,

--- a/assets/aircraft/a388.json
+++ b/assets/aircraft/a388.json
@@ -1,9 +1,17 @@
 {
   "name": "Airbus A380-800",
   "icao": "A388",
-  "wake": "super",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "U",
+  "category": {
+    "srs": 3,
+    "lahso": 10,
+    "recat": "A"
+  },
   "rate": {
-    "turn":       0.7,
     "ascent":     1500,
     "descent":    2000,
     "accelerate": 6,

--- a/assets/aircraft/an12.json
+++ b/assets/aircraft/an12.json
@@ -1,9 +1,17 @@
 {
   "name": "Antonov 12",
   "icao": "AN12",
-  "wake": "medium",
+  "engines": {
+    "number": 4,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.5,
     "ascent":     1960,
     "descent":    2200,
     "accelerate": 5,

--- a/assets/aircraft/an24.json
+++ b/assets/aircraft/an24.json
@@ -1,7 +1,16 @@
 {
   "name": "Antonov 24",
   "icao": "AN24",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "D"
+  },
   "rate": {
     "turn":       1.0,
     "ascent":     1800,

--- a/assets/aircraft/an72.json
+++ b/assets/aircraft/an72.json
@@ -1,9 +1,17 @@
 {
   "name": "Antonov 72",
   "icao": "AN72",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     2100,
     "descent":    1800,
     "accelerate": 8,

--- a/assets/aircraft/at43.json
+++ b/assets/aircraft/at43.json
@@ -1,16 +1,24 @@
 {
   "name": "ATR 42-300",
   "icao": "AT43",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 3,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       2.5,
     "ascent":     1700,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 6
   },
   "runway": {
-    "takeoff": 1.8,
+    "takeoff": 1.8, 
     "landing": 2.1
   },
   "speed":{

--- a/assets/aircraft/at72.json
+++ b/assets/aircraft/at72.json
@@ -1,9 +1,17 @@
 {
   "name": "ATR 72-500",
   "icao": "AT72",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 3,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       2.8,
     "ascent":     2100,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/b733.json
+++ b/assets/aircraft/b733.json
@@ -1,7 +1,16 @@
 {
   "name": "Boeing 737-300",
   "icao": "B733",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
     "ascent":     1100,
     "descent":    1800,

--- a/assets/aircraft/b734.json
+++ b/assets/aircraft/b734.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-400",
   "icao": "B734",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 8,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1100,
     "descent":    1800,
     "accelerate": 6,

--- a/assets/aircraft/b735.json
+++ b/assets/aircraft/b735.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-500",
   "icao": "B735",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.6,
     "ascent":     1500,
     "descent":    1900,
     "accelerate": 7,

--- a/assets/aircraft/b736.json
+++ b/assets/aircraft/b736.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-600",
   "icao": "B736",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.4,
     "ascent":     1600,
     "descent":    2100,
     "accelerate": 7,

--- a/assets/aircraft/b737.json
+++ b/assets/aircraft/b737.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-700",
   "icao": "B737",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 8,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1300,
     "descent":    2000,
     "accelerate": 7,

--- a/assets/aircraft/b738.json
+++ b/assets/aircraft/b738.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-800",
   "icao": "B738",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 7,

--- a/assets/aircraft/b739.json
+++ b/assets/aircraft/b739.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 737-900",
   "icao": "B739",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 7,

--- a/assets/aircraft/b744.json
+++ b/assets/aircraft/b744.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 747-400",
   "icao": "B744",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 10,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1000,
     "descent":    2000,
     "accelerate": 4,

--- a/assets/aircraft/b748.json
+++ b/assets/aircraft/b748.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 747-8i",
   "icao": "B748",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 10,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.9,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 6,

--- a/assets/aircraft/b752.json
+++ b/assets/aircraft/b752.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 757-200",
   "icao": "B752",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1800,
     "descent":    2100,
     "accelerate": 8,

--- a/assets/aircraft/b753.json
+++ b/assets/aircraft/b753.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 757-300",
   "icao": "B753",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 8,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1800,
     "descent":    2100,
     "accelerate": 8,

--- a/assets/aircraft/b762.json
+++ b/assets/aircraft/b762.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 767-200",
   "icao": "B762",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1500,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/b763.json
+++ b/assets/aircraft/b763.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 767-300",
   "icao": "B763",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1500,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/b764.json
+++ b/assets/aircraft/b764.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 767-300",
   "icao": "B763",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1500,
     "descent":    2500,
     "accelerate": 8,

--- a/assets/aircraft/b772.json
+++ b/assets/aircraft/b772.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 777-200",
   "icao": "B772",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 6,

--- a/assets/aircraft/b773.json
+++ b/assets/aircraft/b773.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 777-300",
   "icao": "B773",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 5.5,

--- a/assets/aircraft/b77e.json
+++ b/assets/aircraft/b77e.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 777-200ER",
-  "icao": "B77E",
-  "wake": "heavy",
+  "icao": "B772",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 6,

--- a/assets/aircraft/b77w.json
+++ b/assets/aircraft/b77w.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 777-300ER",
   "icao": "B77W",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1100,
     "descent":    2200,
     "accelerate": 6,

--- a/assets/aircraft/b788.json
+++ b/assets/aircraft/b788.json
@@ -1,9 +1,17 @@
 {
   "name": "Boeing 787-8 Dreamliner",
   "icao": "B788",
-  "wake": "heavy",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       1.4,
     "ascent":     1700,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/be36.json
+++ b/assets/aircraft/be36.json
@@ -1,7 +1,16 @@
 {
   "name": "Beechcraft Bonanza",
   "icao": "BE36",
-  "wake": "light",
+  "engines": {
+    "number": 1,
+    "type": "P"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 1,
+    "lahso": 2,
+    "recat": "F"
+  },
   "rate": {
     "ascent":     1230,
     "descent":    2000,

--- a/assets/aircraft/c130.json
+++ b/assets/aircraft/c130.json
@@ -1,9 +1,17 @@
 {
   "name": "Lockheed C-130 Hercules",
   "icao": "C130",
-  "wake": "medium",
+  "engines": {
+    "number": 4,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.0,
     "ascent":     1830,
     "descent":    2100,
     "accelerate": 7,

--- a/assets/aircraft/c172.json
+++ b/assets/aircraft/c172.json
@@ -1,7 +1,16 @@
 {
   "name": "Cessna 172 Skyhawk",
   "icao": "C172",
-  "wake": "light",
+  "engines": {
+    "number": 1,
+    "type": "P"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 1,
+    "lahso": 1,
+    "recat": "F"
+  },
   "rate": {
     "ascent":     730,
     "descent":    1460,

--- a/assets/aircraft/c182.json
+++ b/assets/aircraft/c182.json
@@ -1,7 +1,16 @@
 {
   "name": "Cessna 182 Skylane",
   "icao": "C182",
-  "wake": "light",
+  "engines": {
+    "number": 1,
+    "type": "P"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 1,
+    "lahso": 2,
+    "recat": "F"
+  },
   "rate": {
     "ascent":     924,
     "descent":    1820,

--- a/assets/aircraft/c208.json
+++ b/assets/aircraft/c208.json
@@ -1,9 +1,17 @@
 {
   "name": "Cessna 208 Caravan",
   "icao": "C208",
-  "wake": "medium",
+  "engines": {
+    "number": 1,
+    "type": "T"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 1,
+    "lahso": 3,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       2.5,
     "ascent":     1700,
     "descent":    2500,
     "accelerate": 8,

--- a/assets/aircraft/c337.json
+++ b/assets/aircraft/c337.json
@@ -1,9 +1,17 @@
 {
   "name": "Cessna 337 Super Skymaster",
   "icao": "C337",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "P"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 2,
+    "lahso": 3,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       5.0,
     "ascent":     900,
     "descent":    1500,
     "accelerate": 4,

--- a/assets/aircraft/c5.json
+++ b/assets/aircraft/c5.json
@@ -1,9 +1,17 @@
 {
   "name": "Lockheed C-5 Galaxy ",
   "icao": "C5",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1000,
     "descent":    2000,
     "accelerate": 4,

--- a/assets/aircraft/c510.json
+++ b/assets/aircraft/c510.json
@@ -1,9 +1,17 @@
 {
   "name": "Cessna Citation Mustang",
   "icao": "C510",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       4.3,
     "ascent":     2500,
     "descent":    3000,
     "accelerate": 10,

--- a/assets/aircraft/c550.json
+++ b/assets/aircraft/c550.json
@@ -1,9 +1,17 @@
 {
   "name": "Cessna Citation II",
   "icao": "C550",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       3.2,
     "ascent":     2200,
     "descent":    2500,
     "accelerate": 8,

--- a/assets/aircraft/c750.json
+++ b/assets/aircraft/c750.json
@@ -1,9 +1,17 @@
 {
   "name": "Cessna Citation X",
   "icao": "C750",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       1.8,
     "ascent":     2200,
     "descent":    2500,
     "accelerate": 10,

--- a/assets/aircraft/conc.json
+++ b/assets/aircraft/conc.json
@@ -1,8 +1,17 @@
 {
   "name": "Concorde",
   "icao": "CONC",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       0.3,
     "ascent":     4000,
     "descent":    2000,
     "accelerate": 4,

--- a/assets/aircraft/dc10.json
+++ b/assets/aircraft/dc10.json
@@ -1,9 +1,17 @@
 {
-  "name": "McDonnel Douglas DC-10",
+  "name": "McDonnell Douglas DC-10",
   "icao": "DC10",
-  "wake": "heavy",
+  "engines": {
+    "number": 3,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1300,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/dh8d.json
+++ b/assets/aircraft/dh8d.json
@@ -1,9 +1,17 @@
 {
   "name": "Bombardier Dash 8 Q400",
   "icao": "DH8D",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 6,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       3,
     "ascent":     3000,
     "descent":    2500,
     "accelerate": 10,

--- a/assets/aircraft/e110.json
+++ b/assets/aircraft/e110.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer 110 Bandeirante",
   "icao": "E110",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       1.7,
     "ascent":     1200,
     "descent":    1800,
     "accelerate": 5,

--- a/assets/aircraft/e120.json
+++ b/assets/aircraft/e120.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer 120 Brasília",
   "icao": "E120",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       2.0,
     "ascent":     1200,
     "descent":    1500,
     "accelerate": 6,

--- a/assets/aircraft/e135.json
+++ b/assets/aircraft/e135.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer Legacy 600",
   "icao": "E135",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       3.2,
     "ascent":     2700,
     "descent":    2500,
     "accelerate": 10,

--- a/assets/aircraft/e170.json
+++ b/assets/aircraft/e170.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer 170/175",
   "icao": "E170",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       1.3,
     "ascent":     1900,
     "descent":    2100,
     "accelerate": 7,

--- a/assets/aircraft/e190.json
+++ b/assets/aircraft/e190.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer 190/195",
   "icao": "E190",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.5,
     "ascent":     1900,
     "descent":    2100,
     "accelerate": 7,

--- a/assets/aircraft/e50p.json
+++ b/assets/aircraft/e50p.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer Phenom 100",
   "icao": "E50P",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       4.3,
     "ascent":     2500,
     "descent":    3000,
     "accelerate": 10,

--- a/assets/aircraft/e545.json
+++ b/assets/aircraft/e545.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer Legacy 600",
   "icao": "E545",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       3.2,
     "ascent":     2700,
     "descent":    2500,
     "accelerate": 10,

--- a/assets/aircraft/e55p.json
+++ b/assets/aircraft/e55p.json
@@ -1,9 +1,17 @@
 {
   "name": "Embraer Phenom 300",
   "icao": "E55P",
-  "wake": "light",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       4.3,
     "ascent":     2500,
     "descent":    3000,
     "accelerate": 10,

--- a/assets/aircraft/f100.json
+++ b/assets/aircraft/f100.json
@@ -1,9 +1,17 @@
 {
   "name": "Fokker 100",
   "icao": "F100",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.2,
     "ascent":     1100,
     "descent":    1800,
     "accelerate": 6,

--- a/assets/aircraft/il76.json
+++ b/assets/aircraft/il76.json
@@ -1,9 +1,17 @@
 {
   "name": "Ilyushin Il-76",
   "icao": "IL76",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 5,

--- a/assets/aircraft/il96.json
+++ b/assets/aircraft/il96.json
@@ -1,9 +1,17 @@
 {
   "name": "Ilyushin Il-96-300",
   "icao": "IL96",
-  "wake": "heavy",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "B"
+  },
   "rate": {
-    "turn":       0.8,
     "ascent":     1200,
     "descent":    2000,
     "accelerate": 5,

--- a/assets/aircraft/l410.json
+++ b/assets/aircraft/l410.json
@@ -1,9 +1,17 @@
 {
   "name": "Let 410",
   "icao": "L410",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "T"
+  },
+  "weightclass": "S+",
+  "category": {
+    "srs": 2,
+    "lahso": null,
+    "recat": "F"
+  },
   "rate": {
-    "turn":       2.0,
     "ascent":     1700,
     "descent":    2500,
     "accelerate": 8,

--- a/assets/aircraft/md11.json
+++ b/assets/aircraft/md11.json
@@ -1,9 +1,17 @@
 {
   "name": "McDonnel Douglas MD-11",
   "icao": "MD11",
-  "wake": "heavy",
+  "engines": {
+    "number": 3,
+    "type": "J"
+  },
+  "weightclass": "H",
+  "category": {
+    "srs": 3,
+    "lahso": 9,
+    "recat": "C"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1300,
     "descent":    2500,
     "accelerate": 7,

--- a/assets/aircraft/p28a.json
+++ b/assets/aircraft/p28a.json
@@ -1,7 +1,16 @@
 {
   "name": "Piper PA-28 Cherokee",
   "icao": "P28A",
-  "wake": "light",
+  "engines": {
+    "number": 1,
+    "type": "P"
+  },
+  "weightclass": "S",
+  "category": {
+    "srs": 1,
+    "lahso": 1,
+    "recat": "F"
+  },
   "rate": {
     "ascent":     660,
     "descent":    1320,

--- a/assets/aircraft/rj85.json
+++ b/assets/aircraft/rj85.json
@@ -1,9 +1,17 @@
 {
   "name": "Avro RJ85",
   "icao": "RJ85",
-  "wake": "medium",
+  "engines": {
+    "number": 4,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": 7,
+    "recat": "E"
+  },
   "rate": {
-    "turn":       3,
     "ascent":     2000,
     "descent":    2500,
     "accelerate": 10,

--- a/assets/aircraft/t154.json
+++ b/assets/aircraft/t154.json
@@ -1,9 +1,17 @@
 {
   "name": "Tupolev 154",
   "icao": "T154",
-  "wake": "medium",
+  "engines": {
+    "number": 3,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     2000,
     "descent":    2200,
     "accelerate": 9,

--- a/assets/aircraft/t204.json
+++ b/assets/aircraft/t204.json
@@ -1,9 +1,17 @@
 {
   "name": "Tu-204-300",
   "icao": "T204",
-  "wake": "medium",
+  "engines": {
+    "number": 2,
+    "type": "J"
+  },
+  "weightclass": "L",
+  "category": {
+    "srs": 3,
+    "lahso": null,
+    "recat": "D"
+  },
   "rate": {
-    "turn":       1.1,
     "ascent":     1800,
     "descent":    2100,
     "accelerate": 8,

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -246,7 +246,9 @@ var Model=Fiber.extend(function() {
       this.name = null;
       this.icao = null;
 
-      this.wake = null;
+      this.engines = null;
+      this.weightclass = null;
+      this.category = null;
 
       this.rate = {
         turn:       0, // radians per second
@@ -259,7 +261,7 @@ var Model=Fiber.extend(function() {
       this.runway = {
         takeoff: 0, // km needed to takeoff
         landing: 0,
-      }
+      };
 
       this.speed = {
         min:     0,
@@ -277,13 +279,14 @@ var Model=Fiber.extend(function() {
       if(data.name) this.name = data.name;
       if(data.icao) this.icao = data.icao;
 
-      if(data.wake) this.wake = data.wake;
+      if(data.engines) this.engines = data.engines;
+      if(data.weightclass) this.weightclass = data.weightclass;
+      if(data.category) this.category = data.category;
 
       if(data.rate) {
         this.rate         = data.rate;
         this.rate.ascent  = this.rate.ascent  / 60;
         this.rate.descent = this.rate.descent / 60;
-        this.rate.turn    = radians(this.rate.turn);
       }
 
       if(data.runway) this.runway = data.runway;
@@ -772,8 +775,8 @@ var Aircraft=Fiber.extend(function() {
     },
     getRadioCallsign: function(condensed) {
       var heavy = "";
-      if(this.model.wake == "heavy") heavy = " heavy"
-      if(this.model.wake == "super") heavy = " super"
+      if(this.model.weightclass == "H") heavy = " heavy"
+      if(this.model.weightclass == "U") heavy = " super"
       var callsign = this.callsign;
       if(condensed) {
         var length = 2;
@@ -2195,8 +2198,8 @@ function aircraft_init() {
   aircraft_load("b764");
 
   aircraft_load("b772");
-  aircraft_load("b773");
   aircraft_load("b77e");
+  aircraft_load("b773");
   aircraft_load("b77w");
   aircraft_load("b788");
 


### PR DESCRIPTION
All changes are back-end only, and shouldn't affect anything. Just provides more information that will be referenced later on for various separation & wake turbulence rules. Large number of lines changed, but really it's just the same thing being added to all 64 aircraft, with different values of course. For example:

```
"engines": {
    "number": 2,
    "type": "J"
  },
  "weightclass": "H",
  "category": {
    "srs": 3,
    "lahso": 9,
    "recat": "B"
  },
```

Helps prep for work on #326, and would check boxes 1a-1e.
