### PR TITLE
Make all altitude entries in hundreds of feet (aka flight levels) - resolves #342

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -656,7 +656,7 @@ var Aircraft=Fiber.extend(function() {
           var distance = round(vlen(this.position) * 0.62);
           position += distance + " mile" + s(distance);
           var angle = vradial(this.position);
-          position += " " + radio_compass(compass_direction(angle));
+          position += " " + radio_cardinalDir(getCardinalDirection(angle));
           ui_log(airport_get().radio+" tower, "+this.getRadioCallsign()+" in your airspace "+position+", over");
           this.inside_ctr = true;
         } else if(this.category == "departure") {
@@ -717,7 +717,7 @@ var Aircraft=Fiber.extend(function() {
           var position = "";
           var distance = round(this.distance * 0.62);
           position += distance + " mile" + s(distance);
-          position += " " + radio_compass(compass_direction(this.radial));
+          position += " " + radio_cardinalDir(getCardinalDirection(this.radial));
           var altitude = " ";
           if (abs(this.altitude - this.fms.currentWaypoint().altitude) > 100) {
             altitude += "leaving " + (Math.floor(this.altitude / 100) * 100) +
@@ -782,7 +782,7 @@ var Aircraft=Fiber.extend(function() {
         var length = 2;
         callsign = callsign.substr(callsign.length - length);
       }
-      return airline_get(this.airline).callsign + " " + radio(callsign.toUpperCase()) + heavy;
+      return airline_get(this.airline).callsign + " " + radio_spellOut(callsign) + heavy;
     },
     hideStrip: function() {
       this.html.hide(600);
@@ -1127,8 +1127,9 @@ var Aircraft=Fiber.extend(function() {
       else         expedite = "";
 
       if(this.isTakeoff())
-        return ['ok', 'after departure, ' + radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + ' ' + this.fms.currentWaypoint().altitude + expedite];
-      return ['ok', radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + ' ' + this.fms.currentWaypoint().altitude + expedite];
+        return ['ok', 'after departure, ' + radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) 
+          + ' ' + radio_altitude(this.fms.currentWaypoint().altitude) + expedite];
+      return ['ok', radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + ' ' + radio_altitude(this.fms.currentWaypoint().altitude) + expedite];
     },
     runSpeed: function(data) {
       if(data[0] == "+" || data[0] == "-") {  //shortKey '+' or '-' in use

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1090,7 +1090,6 @@ var Aircraft=Fiber.extend(function() {
       var expedite = false;
       data = split[0];
 
-
       function isExpedite(s) {
         if((s.length >= 1 && "expedite".indexOf(s) == 0) || s == "x") return true;
         return false;
@@ -1101,14 +1100,10 @@ var Aircraft=Fiber.extend(function() {
       }
 
       if(isNaN(altitude)) {
-        // if(split[0][0] == "v" || split[0][0] == "^") {
-        //   altitude = parseInt(split[0].substr(1));  //remove shortKey
-        // }
         if(isExpedite(split[0])) {
           this.setCurrent({expedite: true});
           if(this.isTakeoff())
             return ['ok', 'after departure, ' + radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + " " + this.fms.currentWaypoint().altitude + ' expedite'];
-
           return ['ok', radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + " " + this.fms.currentWaypoint().altitude + ' expedite'];
         }
         return ["fail", "altitude not understood", "say again"];
@@ -1117,15 +1112,11 @@ var Aircraft=Fiber.extend(function() {
       if(this.mode == "landing")
         this.cancelLanding();
 
-      var digits = altitude.toString().length;
-      if(digits == 1) altitude *= 1000;
-      else if(digits == 2) altitude *= 100;
-      else if(digits == 3) altitude *= 100;
-      else if(digits == 4) altitude *= 1;
-
       var ceiling = airport_get().ctr_ceiling;
       if (prop.game.option.get('softCeiling') == 'yes')
         ceiling += 1000;
+
+      altitude *= 100;
 
       this.fms.setAll({
         altitude: clamp(1000, altitude, ceiling),
@@ -1137,7 +1128,6 @@ var Aircraft=Fiber.extend(function() {
 
       if(this.isTakeoff())
         return ['ok', 'after departure, ' + radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + ' ' + this.fms.currentWaypoint().altitude + expedite];
-
       return ['ok', radio_trend('altitude', this.altitude, this.fms.currentWaypoint().altitude) + ' ' + this.fms.currentWaypoint().altitude + expedite];
     },
     runSpeed: function(data) {

--- a/assets/scripts/tutorial.js
+++ b/assets/scripts/tutorial.js
@@ -78,8 +78,8 @@ function tutorial_init_pre() {
   tutorial_step({
     title:    "Takeoff, part 1",
     text:     ["When it appears at the start of runway {RUNWAY} (which may take a couple of seconds), click it (or press the up arrow once)",
-               "and type in &lsquo;climb 5000&rsquo;. This clears the aircraft to climb to five thousand",
-               "feet after it takes off. (This step must be done before clearing the aircraft for take off, just as in real life.)"
+               "and type in &lsquo;climb 50&rsquo;. This clears the aircraft to climb to five thousand",
+               "feet after it takes off. (This step must be done before clearing the aircraft for takeoff, just as in real life.)"
                ].join(" "),
     parse:    function(t) {
       return t.replace("{RUNWAY}", prop.aircraft.list[0].fms.currentWaypoint().runway);
@@ -166,8 +166,8 @@ function tutorial_init_pre() {
     text:     ["You can assign altitudes with the &lsquo;climb&rsquo; command, or any of its aliases (other words that",
                "act identically). Running the command &lsquo;climb&rsquo; is the same as the commands &lsquo;descend&rsquo;, &lsquo;d&rsquo;,",
                "&lsquo;clear&rsquo;, &lsquo;c&rsquo;, &lsquo;altitude&rsquo;, or &lsquo;a&rsquo;. Just use whichever feels correct in your situation.",
-               "You may enter altitudes in feet, hundreds of feet, or thousands of feet (eg. &lsquo;climb 5&rsquo; = &lsquo;climb 50&rsquo;",
-               " = &lsquo;climb 5000&rsquo;)."
+               "Remember, just as in real ATC, altitudes are ALWAYS written in hundreds of feet, eg. &lsquo;descend 30&rsquo; for 3,000ft or &lsquo;climb",
+               " 100&rsquo; for 10,000ft."
                ].join(" "),
     parse:    function(t) {
       return t.replace("{CALLSIGN}", prop.aircraft.list[0].getCallsign());

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -276,11 +276,15 @@ var radio_names = {
   ".":"point",
 };
 
-var radio_compass_names = {
+var radio_cardinalDir_names = {
   "n":"north",
+  "nw":"northwest",
   "w":"west",
+  "sw":"southwest",
   "s":"south",
+  "se":"southeast",
   "e":"east",
+  "ne":"northeast"
 };
 
 var radio_runway_names = clone(radio_names);
@@ -289,7 +293,7 @@ radio_runway_names.l = "left";
 radio_runway_names.c = "center";
 radio_runway_names.r = "right";
 
-function radio(input) {
+function radio_spellOut(input) {
   input = input + "";
   input = input.toLowerCase();
   var s = [];
@@ -311,12 +315,12 @@ function radio_runway(input) {
   return s.join(" ");
 }
 
-function radio_compass(input) {
+function radio_cardinalDir(input) {
   input = input + "";
   input = input.toLowerCase();
   var s = [];
   for(var i=0;i<input.length;i++) {
-    var c = radio_compass_names[input[i]];
+    var c = radio_cardinalDir_names[input[i]];
     if(c) s.push(c);
   }
   return s.join(" ");
@@ -332,14 +336,14 @@ function radio_trend(category, measured, target) {
   return CATEGORIES[category][2];
 }
 
-var DIRECTIONS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+function radio_altitude(alt) {
+  if(alt >= 18000) return "flight level " + parseInt(alt.toString().substr(0,3));
+  else return alt;
+}
 
-function compass_direction(angle) {
-  angle /= Math.PI*2;
-  angle = round(mod(angle, 1) * 8);
-  if(angle == 8) return "NW";
-  angle = DIRECTIONS[round(angle)];
-  return angle;
+function getCardinalDirection(angle) {
+  var directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW", "N"];
+  return directions[round(angle / (Math.PI*2) * 8)];
 }
 
 // Return a random number within the given interval

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -337,8 +337,8 @@ function radio_trend(category, measured, target) {
 }
 
 function radio_altitude(alt) {
-  if(alt >= 18000) return "flight level " + parseInt(alt.toString().substr(0,3));
-  else return alt;
+  if(alt >= 18000) return "flight level " + round(alt/100).toString();
+  else return alt.toString();
 }
 
 function getCardinalDirection(angle) {

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -45,7 +45,7 @@ _Aliases -_ climb / descend / clear / altitude
 
 _Abbreviations -_ a, c, d
 
-_Information -_ This command tells the specified plane the altitude, in feet, it should travel to.  Note that you are able to type "5" or "8" in order to quickly type figures such as "5000" or "8000". Airplanes will not descend below 1000 feet (unless locked on ILS) or above 10000.
+_Information -_ This command tells the specified plane the altitude, in hundreds of feet (flight levels), it should travel to. This means that when writing altitudes you would drop the last two zeros. For example, 3,000ft = "30", 8,300ft = "83", 10,000ft = "100", and FL180 (18,000ft) = "180". Airplanes will not descend below 1000 feet (unless locked on ILS) or above 10000.
 
 _Syntax -_ (Callsign) (climb|descend|clear|altitude) (new altitude, in feet)
 


### PR DESCRIPTION
Resolves the issues brought up in and the resulting discussions from #342.

The tutorial and wiki were updated to show that you must now enter altitudes in hundreds of feet, eg:
- 3,000ft = "30"
- 7,500 = "75"
- FL180 (18,000) = "180"
