### PR TITLE
Dynamic climb rate

### DIFF
--- a/assets/aircraft/a124.json
+++ b/assets/aircraft/a124.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 40000,
   "rate": {
-    "climb":      1000,
-    "descent":    2000,
+    "climb":      2000,
+    "descent":    1670,
     "accelerate": 4,
     "decelerate": 2
   },

--- a/assets/aircraft/a124.json
+++ b/assets/aircraft/a124.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1000,
+    "climb":      1000,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 2

--- a/assets/aircraft/a306.json
+++ b/assets/aircraft/a306.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1800,
-    "descent":    2100,
+    "climb":      3500,
+    "descent":    2000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/a306.json
+++ b/assets/aircraft/a306.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2100,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/a318.json
+++ b/assets/aircraft/a318.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 39000,
   "rate": {
-    "climb":      1900,
-    "descent":    2100,
+    "climb":      3500,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/a318.json
+++ b/assets/aircraft/a318.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1900,
+    "climb":      1900,
     "descent":    2100,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/a319.json
+++ b/assets/aircraft/a319.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1600,
+    "climb":      1600,
     "descent":    1800,
     "accelerate": 6.5,
     "decelerate": 4

--- a/assets/aircraft/a319.json
+++ b/assets/aircraft/a319.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 39000,
   "rate": {
-    "climb":      1600,
-    "descent":    1800,
+    "climb":      3500,
+    "descent":    3000,
     "accelerate": 6.5,
     "decelerate": 4
   },

--- a/assets/aircraft/a320.json
+++ b/assets/aircraft/a320.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2000,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/a320.json
+++ b/assets/aircraft/a320.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 39000,
   "rate": {
-    "climb":      1800,
-    "descent":    2000,
+    "climb":      3500,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/a321.json
+++ b/assets/aircraft/a321.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2000,
     "accelerate": 6,
     "decelerate": 4

--- a/assets/aircraft/a321.json
+++ b/assets/aircraft/a321.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1800,
-    "descent":    2000,
+    "climb":      3500,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 4
   },

--- a/assets/aircraft/a332.json
+++ b/assets/aircraft/a332.json
@@ -11,10 +11,10 @@
     "lahso": 8,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      3500,
+    "descent":    2000,
     "accelerate": 6,
     "decelerate": 3.5
   },

--- a/assets/aircraft/a332.json
+++ b/assets/aircraft/a332.json
@@ -11,8 +11,9 @@
     "lahso": 8,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 3.5

--- a/assets/aircraft/a333.json
+++ b/assets/aircraft/a333.json
@@ -11,10 +11,10 @@
     "lahso": 8,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      3500,
+    "descent":    2000,
     "accelerate": 6,
     "decelerate": 3.5
   },

--- a/assets/aircraft/a333.json
+++ b/assets/aircraft/a333.json
@@ -11,8 +11,9 @@
     "lahso": 8,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 3.5

--- a/assets/aircraft/a343.json
+++ b/assets/aircraft/a343.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/a343.json
+++ b/assets/aircraft/a343.json
@@ -11,9 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1200,
+    "climb":      3500,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/a346.json
+++ b/assets/aircraft/a346.json
@@ -11,11 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "turn":       0.8,
-    "climb":      1400,
-    "descent":    2200,
+    "climb":      3500,
+    "descent":    2000,
     "accelerate": 6,
     "decelerate": 4
   },

--- a/assets/aircraft/a346.json
+++ b/assets/aircraft/a346.json
@@ -11,9 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
     "turn":       0.8,
-    "ascent":     1400,
+    "climb":      1400,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 4

--- a/assets/aircraft/a388.json
+++ b/assets/aircraft/a388.json
@@ -11,8 +11,9 @@
     "lahso": 10,
     "recat": "A"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1500,
+    "climb":      1500,
     "descent":    2000,
     "accelerate": 6,
     "decelerate": 4

--- a/assets/aircraft/a388.json
+++ b/assets/aircraft/a388.json
@@ -11,9 +11,9 @@
     "lahso": 10,
     "recat": "A"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1500,
+    "climb":      2500,
     "descent":    2000,
     "accelerate": 6,
     "decelerate": 4

--- a/assets/aircraft/an12.json
+++ b/assets/aircraft/an12.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1960,
+    "climb":      1960,
     "descent":    2200,
     "accelerate": 5,
     "decelerate": 4

--- a/assets/aircraft/an12.json
+++ b/assets/aircraft/an12.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 39000,
   "rate": {
-    "climb":      1960,
-    "descent":    2200,
+    "climb":      1500,
+    "descent":    1670,
     "accelerate": 5,
     "decelerate": 4
   },

--- a/assets/aircraft/an24.json
+++ b/assets/aircraft/an24.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 27500,
   "rate": {
-    "climb":      1800,
-    "descent":    2000,
+    "climb":      1500,
+    "descent":    1500,
     "accelerate": 6,
     "decelerate": 4
   },

--- a/assets/aircraft/an24.json
+++ b/assets/aircraft/an24.json
@@ -11,9 +11,9 @@
     "lahso": null,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "turn":       1.0,
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2000,
     "accelerate": 6,
     "decelerate": 4

--- a/assets/aircraft/an72.json
+++ b/assets/aircraft/an72.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2100,
+    "climb":      2100,
     "descent":    1800,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/an72.json
+++ b/assets/aircraft/an72.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 35000,
   "rate": {
-    "climb":      2100,
-    "descent":    1800,
+    "climb":      1500,
+    "descent":    1670,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/at43.json
+++ b/assets/aircraft/at43.json
@@ -11,8 +11,9 @@
     "lahso": 3,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1700,
+    "climb":      1700,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 6

--- a/assets/aircraft/at43.json
+++ b/assets/aircraft/at43.json
@@ -13,8 +13,8 @@
   },
   "ceiling": 25000,
   "rate": {
-    "climb":      1700,
-    "descent":    2500,
+    "climb":      1800,
+    "descent":    1500,
     "accelerate": 7,
     "decelerate": 6
   },

--- a/assets/aircraft/at72.json
+++ b/assets/aircraft/at72.json
@@ -11,8 +11,9 @@
     "lahso": 3,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2100,
+    "climb":      2100,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 5

--- a/assets/aircraft/at72.json
+++ b/assets/aircraft/at72.json
@@ -13,8 +13,8 @@
   },
   "ceiling": 25000,
   "rate": {
-    "climb":      2100,
-    "descent":    2500,
+    "climb":      1800,
+    "descent":    1500,
     "accelerate": 7,
     "decelerate": 5
   },

--- a/assets/aircraft/b733.json
+++ b/assets/aircraft/b733.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1100,
-    "descent":    1800,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3
   },

--- a/assets/aircraft/b733.json
+++ b/assets/aircraft/b733.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    1800,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/b734.json
+++ b/assets/aircraft/b734.json
@@ -11,8 +11,9 @@
     "lahso": 8,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    1800,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/b734.json
+++ b/assets/aircraft/b734.json
@@ -11,10 +11,10 @@
     "lahso": 8,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 37000,
   "rate": {
-    "climb":      1100,
-    "descent":    1800,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3
   },

--- a/assets/aircraft/b735.json
+++ b/assets/aircraft/b735.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 37000,
   "rate": {
-    "climb":      1500,
-    "descent":    1900,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 5
   },

--- a/assets/aircraft/b735.json
+++ b/assets/aircraft/b735.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1500,
+    "climb":      1500,
     "descent":    1900,
     "accelerate": 7,
     "decelerate": 5

--- a/assets/aircraft/b736.json
+++ b/assets/aircraft/b736.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1600,
+    "climb":      1600,
     "descent":    2100,
     "accelerate": 7,
     "decelerate": 3

--- a/assets/aircraft/b736.json
+++ b/assets/aircraft/b736.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1600,
-    "descent":    2100,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 3
   },

--- a/assets/aircraft/b737.json
+++ b/assets/aircraft/b737.json
@@ -11,8 +11,9 @@
     "lahso": 8,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1300,
+    "climb":      1300,
     "descent":    2000,
     "accelerate": 7,
     "decelerate": 3

--- a/assets/aircraft/b737.json
+++ b/assets/aircraft/b737.json
@@ -11,10 +11,10 @@
     "lahso": 8,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1300,
-    "descent":    2000,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 3
   },

--- a/assets/aircraft/b738.json
+++ b/assets/aircraft/b738.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 7,
     "decelerate": 3

--- a/assets/aircraft/b738.json
+++ b/assets/aircraft/b738.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1200,
-    "descent":    2000,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 3
   },

--- a/assets/aircraft/b739.json
+++ b/assets/aircraft/b739.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 7,
     "decelerate": 3

--- a/assets/aircraft/b739.json
+++ b/assets/aircraft/b739.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1200,
-    "descent":    2000,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 3
   },

--- a/assets/aircraft/b744.json
+++ b/assets/aircraft/b744.json
@@ -11,8 +11,9 @@
     "lahso": 10,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1000,
+    "climb":      1000,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 2

--- a/assets/aircraft/b744.json
+++ b/assets/aircraft/b744.json
@@ -11,10 +11,10 @@
     "lahso": 10,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 45000,
   "rate": {
-    "climb":      1000,
-    "descent":    2000,
+    "climb":      2000,
+    "descent":    3000,
     "accelerate": 4,
     "decelerate": 2
   },

--- a/assets/aircraft/b748.json
+++ b/assets/aircraft/b748.json
@@ -11,10 +11,10 @@
     "lahso": 10,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 45000,
   "rate": {
-    "climb":      1200,
-    "descent":    2000,
+    "climb":      2500,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3
   },

--- a/assets/aircraft/b748.json
+++ b/assets/aircraft/b748.json
@@ -11,8 +11,9 @@
     "lahso": 10,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/b752.json
+++ b/assets/aircraft/b752.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1800,
-    "descent":    2100,
+    "climb":      3330,
+    "descent":    3000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/b752.json
+++ b/assets/aircraft/b752.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2100,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/b753.json
+++ b/assets/aircraft/b753.json
@@ -11,8 +11,9 @@
     "lahso": 8,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2100,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/b753.json
+++ b/assets/aircraft/b753.json
@@ -11,10 +11,10 @@
     "lahso": 8,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1800,
-    "descent":    2100,
+    "climb":      3330,
+    "descent":    3000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/b762.json
+++ b/assets/aircraft/b762.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1500,
-    "descent":    2500,
+    "climb":      2500,
+    "descent":    2000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/b762.json
+++ b/assets/aircraft/b762.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1500,
+    "climb":      1500,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/b763.json
+++ b/assets/aircraft/b763.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1500,
-    "descent":    2500,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/b763.json
+++ b/assets/aircraft/b763.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1500,
+    "climb":      1500,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/b764.json
+++ b/assets/aircraft/b764.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1500,
+    "climb":      1500,
     "descent":    2500,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/b764.json
+++ b/assets/aircraft/b764.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1500,
-    "descent":    2500,
+    "climb":      2500,
+    "descent":    3000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/b772.json
+++ b/assets/aircraft/b772.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      2500,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3.5
   },

--- a/assets/aircraft/b772.json
+++ b/assets/aircraft/b772.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 3.5

--- a/assets/aircraft/b773.json
+++ b/assets/aircraft/b773.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 5.5,
     "decelerate": 3.2

--- a/assets/aircraft/b773.json
+++ b/assets/aircraft/b773.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 5.5,
     "decelerate": 3.2
   },

--- a/assets/aircraft/b77e.json
+++ b/assets/aircraft/b77e.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 3.5

--- a/assets/aircraft/b77e.json
+++ b/assets/aircraft/b77e.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3.5
   },

--- a/assets/aircraft/b77w.json
+++ b/assets/aircraft/b77w.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    2200,
     "accelerate": 6,
     "decelerate": 3.5

--- a/assets/aircraft/b77w.json
+++ b/assets/aircraft/b77w.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1100,
-    "descent":    2200,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 6,
     "decelerate": 3.5
   },

--- a/assets/aircraft/b788.json
+++ b/assets/aircraft/b788.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1700,
-    "descent":    2500,
+    "climb":      2700,
+    "descent":    2800,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/b788.json
+++ b/assets/aircraft/b788.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1700,
+    "climb":      1700,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/be36.json
+++ b/assets/aircraft/be36.json
@@ -11,8 +11,9 @@
     "lahso": 2,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1230,
+    "climb":      1230,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/be36.json
+++ b/assets/aircraft/be36.json
@@ -11,10 +11,10 @@
     "lahso": 2,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 16000,
   "rate": {
-    "climb":      1230,
-    "descent":    2000,
+    "climb":      2000,
+    "descent":    1000,
     "accelerate": 4,
     "decelerate": 3
   },

--- a/assets/aircraft/c130.json
+++ b/assets/aircraft/c130.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1830,
+    "climb":      1830,
     "descent":    2100,
     "accelerate": 7,
     "decelerate": 5

--- a/assets/aircraft/c130.json
+++ b/assets/aircraft/c130.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 33000,
   "rate": {
-    "climb":      1830,
-    "descent":    2100,
+    "climb":      1500,
+    "descent":    1670,
     "accelerate": 7,
     "decelerate": 5
   },

--- a/assets/aircraft/c172.json
+++ b/assets/aircraft/c172.json
@@ -11,10 +11,10 @@
     "lahso": 1,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 15000,
   "rate": {
-    "climb":      730,
-    "descent":    1460,
+    "climb":      700,
+    "descent":    1000,
     "accelerate": 4,
     "decelerate": 3
   },

--- a/assets/aircraft/c172.json
+++ b/assets/aircraft/c172.json
@@ -11,8 +11,9 @@
     "lahso": 1,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     730,
+    "climb":      730,
     "descent":    1460,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/c182.json
+++ b/assets/aircraft/c182.json
@@ -11,8 +11,9 @@
     "lahso": 2,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     924,
+    "climb":      924,
     "descent":    1820,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/c182.json
+++ b/assets/aircraft/c182.json
@@ -11,10 +11,10 @@
     "lahso": 2,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 20000,
   "rate": {
-    "climb":      924,
-    "descent":    1820,
+    "climb":      920,
+    "descent":    1000,
     "accelerate": 4,
     "decelerate": 3
   },

--- a/assets/aircraft/c208.json
+++ b/assets/aircraft/c208.json
@@ -11,10 +11,10 @@
     "lahso": 3,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 27000,
   "rate": {
-    "climb":      1700,
-    "descent":    2500,
+    "climb":      1670,
+    "descent":    1000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/c208.json
+++ b/assets/aircraft/c208.json
@@ -11,8 +11,9 @@
     "lahso": 3,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1700,
+    "climb":      1700,
     "descent":    2500,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/c337.json
+++ b/assets/aircraft/c337.json
@@ -11,10 +11,10 @@
     "lahso": 3,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 19500,
   "rate": {
-    "climb":      900,
-    "descent":    1500,
+    "climb":      2000,
+    "descent":    1000,
     "accelerate": 4,
     "decelerate": 3
   },

--- a/assets/aircraft/c337.json
+++ b/assets/aircraft/c337.json
@@ -11,8 +11,9 @@
     "lahso": 3,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     900,
+    "climb":      900,
     "descent":    1500,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/c5.json
+++ b/assets/aircraft/c5.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 37000,
   "rate": {
-    "climb":      1000,
-    "descent":    2000,
+    "climb":      2000,
+    "descent":    3000,
     "accelerate": 4,
     "decelerate": 2
   },

--- a/assets/aircraft/c5.json
+++ b/assets/aircraft/c5.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1000,
+    "climb":      1000,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 2

--- a/assets/aircraft/c510.json
+++ b/assets/aircraft/c510.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2500,
+    "climb":      2500,
     "descent":    3000,
     "accelerate": 10,
     "decelerate": 5

--- a/assets/aircraft/c510.json
+++ b/assets/aircraft/c510.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      2500,
-    "descent":    3000,
+    "climb":      4000,
+    "descent":    2000,
     "accelerate": 10,
     "decelerate": 5
   },

--- a/assets/aircraft/c550.json
+++ b/assets/aircraft/c550.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 45000,
   "rate": {
-    "climb":      2200,
-    "descent":    2500,
+    "climb":      4000,
+    "descent":    2000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/c550.json
+++ b/assets/aircraft/c550.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2200,
+    "climb":      2200,
     "descent":    2500,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/c750.json
+++ b/assets/aircraft/c750.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 51000,
   "rate": {
-    "climb":      2200,
-    "descent":    2500,
+    "climb":      4400,
+    "descent":    3000,
     "accelerate": 10,
     "decelerate": 5
   },

--- a/assets/aircraft/c750.json
+++ b/assets/aircraft/c750.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2200,
+    "climb":      2200,
     "descent":    2500,
     "accelerate": 10,
     "decelerate": 5

--- a/assets/aircraft/conc.json
+++ b/assets/aircraft/conc.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 60000,
   "rate": {
-    "climb":      4000,
-    "descent":    2000,
+    "climb":      5000,
+    "descent":    3000,
     "accelerate": 4,
     "decelerate": 4
   },

--- a/assets/aircraft/conc.json
+++ b/assets/aircraft/conc.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     4000,
+    "climb":      4000,
     "descent":    2000,
     "accelerate": 4,
     "decelerate": 4

--- a/assets/aircraft/dc10.json
+++ b/assets/aircraft/dc10.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1300,
-    "descent":    2500,
+    "climb":      2900,
+    "descent":    2000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/dc10.json
+++ b/assets/aircraft/dc10.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1300,
+    "climb":      1300,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/dh8d.json
+++ b/assets/aircraft/dh8d.json
@@ -11,8 +11,9 @@
     "lahso": 6,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     3000,
+    "climb":      3000,
     "descent":    2500,
     "accelerate": 10,
     "decelerate": 6

--- a/assets/aircraft/dh8d.json
+++ b/assets/aircraft/dh8d.json
@@ -11,10 +11,10 @@
     "lahso": 6,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 27000,
   "rate": {
-    "climb":      3000,
-    "descent":    2500,
+    "climb":      2200,
+    "descent":    1500,
     "accelerate": 10,
     "decelerate": 6
   },

--- a/assets/aircraft/e110.json
+++ b/assets/aircraft/e110.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    1800,
     "accelerate": 5,
     "decelerate": 3

--- a/assets/aircraft/e110.json
+++ b/assets/aircraft/e110.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 26000,
   "rate": {
-    "climb":      1200,
-    "descent":    1800,
+    "climb":      1670,
+    "descent":    1000,
     "accelerate": 5,
     "decelerate": 3
   },

--- a/assets/aircraft/e120.json
+++ b/assets/aircraft/e120.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    1500,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/e120.json
+++ b/assets/aircraft/e120.json
@@ -11,9 +11,9 @@
     "lahso": 7,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 32000,
   "rate": {
-    "climb":      1200,
+    "climb":      1500,
     "descent":    1500,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/e135.json
+++ b/assets/aircraft/e135.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 37000,
   "rate": {
-    "climb":      2700,
-    "descent":    2500,
+    "climb":      2000,
+    "descent":    1670,
     "accelerate": 10,
     "decelerate": 6
   },

--- a/assets/aircraft/e135.json
+++ b/assets/aircraft/e135.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2700,
+    "climb":      2700,
     "descent":    2500,
     "accelerate": 10,
     "decelerate": 6

--- a/assets/aircraft/e170.json
+++ b/assets/aircraft/e170.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1900,
+    "climb":      1900,
     "descent":    2100,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/e170.json
+++ b/assets/aircraft/e170.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1900,
-    "descent":    2100,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/e190.json
+++ b/assets/aircraft/e190.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1900,
-    "descent":    2100,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/e190.json
+++ b/assets/aircraft/e190.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1900,
+    "climb":      1900,
     "descent":    2100,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/e50p.json
+++ b/assets/aircraft/e50p.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2500,
+    "climb":      2500,
     "descent":    3000,
     "accelerate": 10,
     "decelerate": 5

--- a/assets/aircraft/e50p.json
+++ b/assets/aircraft/e50p.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      2500,
-    "descent":    3000,
+    "climb":      1500,
+    "descent":    1670,
     "accelerate": 10,
     "decelerate": 5
   },

--- a/assets/aircraft/e545.json
+++ b/assets/aircraft/e545.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 37000,
   "rate": {
-    "climb":      2700,
-    "descent":    2500,
+    "climb":      1500,
+    "descent":    1500,
     "accelerate": 10,
     "decelerate": 6
   },

--- a/assets/aircraft/e545.json
+++ b/assets/aircraft/e545.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2700,
+    "climb":      2700,
     "descent":    2500,
     "accelerate": 10,
     "decelerate": 6

--- a/assets/aircraft/e55p.json
+++ b/assets/aircraft/e55p.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 45000,
   "rate": {
-    "climb":      2500,
-    "descent":    3000,
+    "climb":      1500,
+    "descent":    1500,
     "accelerate": 10,
     "decelerate": 5
   },

--- a/assets/aircraft/e55p.json
+++ b/assets/aircraft/e55p.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2500,
+    "climb":      2500,
     "descent":    3000,
     "accelerate": 10,
     "decelerate": 5

--- a/assets/aircraft/f100.json
+++ b/assets/aircraft/f100.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 35000,
   "rate": {
-    "climb":      1100,
-    "descent":    1800,
+    "climb":      2000,
+    "descent":    1670,
     "accelerate": 6,
     "decelerate": 3
   },

--- a/assets/aircraft/f100.json
+++ b/assets/aircraft/f100.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1100,
+    "climb":      1100,
     "descent":    1800,
     "accelerate": 6,
     "decelerate": 3

--- a/assets/aircraft/il76.json
+++ b/assets/aircraft/il76.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 39500,
   "rate": {
-    "climb":      1200,
-    "descent":    2000,
+    "climb":      3000,
+    "descent":    1670,
     "accelerate": 5,
     "decelerate": 2
   },

--- a/assets/aircraft/il76.json
+++ b/assets/aircraft/il76.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 5,
     "decelerate": 2

--- a/assets/aircraft/il96.json
+++ b/assets/aircraft/il96.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "B"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1200,
+    "climb":      1200,
     "descent":    2000,
     "accelerate": 5,
     "decelerate": 2

--- a/assets/aircraft/il96.json
+++ b/assets/aircraft/il96.json
@@ -11,9 +11,9 @@
     "lahso": null,
     "recat": "B"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1200,
+    "climb":      2000,
     "descent":    2000,
     "accelerate": 5,
     "decelerate": 2

--- a/assets/aircraft/l410.json
+++ b/assets/aircraft/l410.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 24500,
   "rate": {
-    "climb":      1700,
-    "descent":    2500,
+    "climb":      1670,
+    "descent":    1000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/aircraft/l410.json
+++ b/assets/aircraft/l410.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1700,
+    "climb":      1700,
     "descent":    2500,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/md11.json
+++ b/assets/aircraft/md11.json
@@ -11,8 +11,9 @@
     "lahso": 9,
     "recat": "C"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1300,
+    "climb":      1300,
     "descent":    2500,
     "accelerate": 7,
     "decelerate": 4

--- a/assets/aircraft/md11.json
+++ b/assets/aircraft/md11.json
@@ -11,10 +11,10 @@
     "lahso": 9,
     "recat": "C"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      1300,
-    "descent":    2500,
+    "climb":      2800,
+    "descent":    2000,
     "accelerate": 7,
     "decelerate": 4
   },

--- a/assets/aircraft/p28a.json
+++ b/assets/aircraft/p28a.json
@@ -11,10 +11,10 @@
     "lahso": 1,
     "recat": "F"
   },
-  "ceiling": 25000,
+  "ceiling": 14000,
   "rate": {
-    "climb":      660,
-    "descent":    1320,
+    "climb":      2000,
+    "descent":    1000,
     "accelerate": 4,
     "decelerate": 3
   },

--- a/assets/aircraft/p28a.json
+++ b/assets/aircraft/p28a.json
@@ -11,8 +11,9 @@
     "lahso": 1,
     "recat": "F"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     660,
+    "climb":      660,
     "descent":    1320,
     "accelerate": 4,
     "decelerate": 3

--- a/assets/aircraft/rj85.json
+++ b/assets/aircraft/rj85.json
@@ -11,10 +11,10 @@
     "lahso": 7,
     "recat": "E"
   },
-  "ceiling": 25000,
+  "ceiling": 31000,
   "rate": {
-    "climb":      2000,
-    "descent":    2500,
+    "climb":      1800,
+    "descent":    1670,
     "accelerate": 10,
     "decelerate": 6
   },

--- a/assets/aircraft/rj85.json
+++ b/assets/aircraft/rj85.json
@@ -11,8 +11,9 @@
     "lahso": 7,
     "recat": "E"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2000,
+    "climb":      2000,
     "descent":    2500,
     "accelerate": 10,
     "decelerate": 6

--- a/assets/aircraft/t154.json
+++ b/assets/aircraft/t154.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     2000,
+    "climb":      2000,
     "descent":    2200,
     "accelerate": 9,
     "decelerate": 4

--- a/assets/aircraft/t154.json
+++ b/assets/aircraft/t154.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 43000,
   "rate": {
-    "climb":      2000,
-    "descent":    2200,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 9,
     "decelerate": 4
   },

--- a/assets/aircraft/t204.json
+++ b/assets/aircraft/t204.json
@@ -11,8 +11,9 @@
     "lahso": null,
     "recat": "D"
   },
+  "ceiling": 25000,
   "rate": {
-    "ascent":     1800,
+    "climb":      1800,
     "descent":    2100,
     "accelerate": 8,
     "decelerate": 4

--- a/assets/aircraft/t204.json
+++ b/assets/aircraft/t204.json
@@ -11,10 +11,10 @@
     "lahso": null,
     "recat": "D"
   },
-  "ceiling": 25000,
+  "ceiling": 41000,
   "rate": {
-    "climb":      1800,
-    "descent":    2100,
+    "climb":      3000,
+    "descent":    3000,
     "accelerate": 8,
     "decelerate": 4
   },

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -252,7 +252,7 @@ var Model=Fiber.extend(function() {
 
       this.rate = {
         turn:       0, // radians per second
-        ascent:     0, // feet per second
+        climb:      0, // feet per second
         descent:    0,
         accelerate: 0, // knots per second
         decelerate: 0,
@@ -285,8 +285,8 @@ var Model=Fiber.extend(function() {
       if(data.ceiling) this.ceiling = data.ceiling;
       if(data.rate) {
         this.rate         = data.rate;
-        this.rate.ascent  = this.rate.ascent  / 60;
-        this.rate.descent = this.rate.descent / 60;
+        this.rate.climb  = this.rate.climb;
+        this.rate.descent = this.rate.descent;
       }
 
       if(data.runway) this.runway = data.runway;
@@ -1805,14 +1805,32 @@ var Aircraft=Fiber.extend(function() {
         // ALTITUDE
 
         var distance = null;
-        var expedite_factor = 1.7;
+        var expedite_factor = 1.5;
         this.trend = 0;
         if(this.target.altitude < this.altitude - 0.02) {
-          distance = -this.model.rate.descent * game_delta() / expedite_factor;
+          distance = -this.model.rate.descent/60 * game_delta();
           if(this.mode == "landing") distance *= 3;
           this.trend -= 1;
         } else if(this.target.altitude > this.altitude + 0.02) {
-          distance =  this.model.rate.ascent  * game_delta() / expedite_factor;
+          function getClimbRate(ac) {
+            var a = ac.altitude;
+            var r = ac.model.rate.climb;
+            var c = ac.model.ceiling;
+            if(ac.model.engines.type == "J") var serviceCeilingClimbRate = 500;
+            else var serviceCeilingClimbRate = 100;
+            if(ac.altitude < 36152) { // in troposphere
+              var cr_uncorr = r*420.7* ((1.232*Math.pow((518.6 - 0.00356*a)/518.6, 5.256)) / (518.6 - 0.00356*a));
+              var cr_current = cr_uncorr - (a/c*cr_uncorr) + (a/c*serviceCeilingClimbRate);
+            }
+            else { // in lower stratosphere
+              //re-do for lower stratosphere
+              //Reference: https://www.grc.nasa.gov/www/k-12/rocket/atmos.html 
+              //also recommend using graphing calc from desmos.com
+            }
+            return cr_current;
+          }
+          var climbrate = getClimbRate(this);
+          distance = climbrate/60 * game_delta();
           if(this.mode == "landing") distance *= 1.5;
           this.trend = 1;
         }

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -784,6 +784,24 @@ var Aircraft=Fiber.extend(function() {
       }
       return airline_get(this.airline).callsign + " " + radio_spellOut(callsign) + heavy;
     },
+    getClimbRate: function() {
+      var a = this.altitude;
+      var r = this.model.rate.climb;
+      var c = this.model.ceiling;
+      if(this.model.engines.type == "J") var serviceCeilingClimbRate = 500;
+      else var serviceCeilingClimbRate = 100;
+      if(this.altitude < 36152) { // in troposphere
+        var cr_uncorr = r*420.7* ((1.232*Math.pow((518.6 - 0.00356*a)/518.6, 5.256)) / (518.6 - 0.00356*a));
+        var cr_current = cr_uncorr - (a/c*cr_uncorr) + (a/c*serviceCeilingClimbRate);
+      }
+      else { // in lower stratosphere
+        //re-do for lower stratosphere
+        //Reference: https://www.grc.nasa.gov/www/k-12/rocket/atmos.html 
+        //also recommend using graphing calc from desmos.com
+        return this.model.rate.climb; // <-- NOT VALID! Just a placeholder!
+      }
+      return cr_current;
+    },
     hideStrip: function() {
       this.html.hide(600);
     },
@@ -1812,24 +1830,7 @@ var Aircraft=Fiber.extend(function() {
           if(this.mode == "landing") distance *= 3;
           this.trend -= 1;
         } else if(this.target.altitude > this.altitude + 0.02) {
-          function getClimbRate(ac) {
-            var a = ac.altitude;
-            var r = ac.model.rate.climb;
-            var c = ac.model.ceiling;
-            if(ac.model.engines.type == "J") var serviceCeilingClimbRate = 500;
-            else var serviceCeilingClimbRate = 100;
-            if(ac.altitude < 36152) { // in troposphere
-              var cr_uncorr = r*420.7* ((1.232*Math.pow((518.6 - 0.00356*a)/518.6, 5.256)) / (518.6 - 0.00356*a));
-              var cr_current = cr_uncorr - (a/c*cr_uncorr) + (a/c*serviceCeilingClimbRate);
-            }
-            else { // in lower stratosphere
-              //re-do for lower stratosphere
-              //Reference: https://www.grc.nasa.gov/www/k-12/rocket/atmos.html 
-              //also recommend using graphing calc from desmos.com
-            }
-            return cr_current;
-          }
-          var climbrate = getClimbRate(this);
+          var climbrate = this.getClimbRate();
           distance = climbrate/60 * game_delta();
           if(this.mode == "landing") distance *= 1.5;
           this.trend = 1;

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -282,7 +282,7 @@ var Model=Fiber.extend(function() {
       if(data.engines) this.engines = data.engines;
       if(data.weightclass) this.weightclass = data.weightclass;
       if(data.category) this.category = data.category;
-
+      if(data.ceiling) this.ceiling = data.ceiling;
       if(data.rate) {
         this.rate         = data.rate;
         this.rate.ascent  = this.rate.ascent  / 60;


### PR DESCRIPTION
Adds new values and new logic to make climb and descent performance very believable. Updated the base `rate.climb` and `rate.descent` values to more reasonable figures, and also applied a trend based on air density, since (to my knowledge), without geting super-crazy-accurate with unnecessary math, the most simple, yet accurate way to approximate climb performance is by relating it to density altitude. See the graph below:

![image](https://cloud.githubusercontent.com/assets/5103735/12525611/888136ca-c133-11e5-88e2-3a3e61a5107e.png)

The climb rate is decreased proportionally to density altitude, and ends up at +500fpm (jets) or +100fpm (turboprop/piston) at the aircraft's model's service ceiling, aka `aircraft.model.ceiling`.

_Partially_ resolves #339 (fixed climb rate, but acceleration isn't changed).

Feel free to give it a whirl: [http://erikquinn.github.io/atc](http://erikquinn.github.io/atc)
