### PR TITLE
Phraseology Improvements

### DIFF
--- a/assets/airports/ebbr.json
+++ b/assets/airports/ebbr.json
@@ -2,7 +2,11 @@
   "reference": "https://www.belgocontrol.be/opersite/eaip/eAIP_Main/html/eAIP/EB-AD-2.EBBR-en-GB.html",
   "name": "Brussels-National",
   "level": "easy",
-  "radio": "Brussels",
+  "radio": {
+    "twr": "Brussels Tower",
+    "app": "Brussels Approach",
+    "dep": "Brussels Departure"
+  },
   "icao": "EBBR",
   "iata": "BRU",
   "magnetic_north": 0,

--- a/assets/airports/eddh.json
+++ b/assets/airports/eddh.json
@@ -1,7 +1,11 @@
 {
   "name": "Hamburg Airport",
   "level": "easy",
-  "radio": "Hamburg",
+  "radio": {
+    "twr": "Hamburg Tower",
+    "app": "Hamburg Approach",
+    "dep": "Hamburg Departure"
+  },
   "icao": "EDDH",
   "iata": "HAM",
   "magnetic_north": 0,

--- a/assets/airports/eddm.json
+++ b/assets/airports/eddm.json
@@ -1,7 +1,11 @@
 {
   "name": "Franz Josef Strauß International Airport &#9983",
   "level": "beginner",
-  "radio": "Munich",
+  "radio": {
+    "twr": "Munich Tower",
+    "app": "Munich Approach",
+    "dep": "Munich Departure"
+  },
   "icao": "EDDM",
   "iata": "MUC",
   "magnetic_north": 1.4,

--- a/assets/airports/eglc.json
+++ b/assets/airports/eglc.json
@@ -1,7 +1,11 @@
 {
   "name": "London City Airport",
   "level": "medium",
-  "radio": "City",
+  "radio": {
+    "twr": "City Tower",
+    "app": "City Approach",
+    "dep": "City Departure"
+  },
   "icao": "EGLC",
   "iata": "LCY",
   "magnetic_north": 0,

--- a/assets/airports/eham.json
+++ b/assets/airports/eham.json
@@ -1,7 +1,11 @@
 {
   "name": "Amsterdam Airport Schiphol",
   "level": "medium",
-  "radio": "Amsterdam",
+  "radio": {
+    "twr": "Amsterdam Tower",
+    "app": "Amsterdam Approach",
+    "dep": "Amsterdam Departure"
+  },
   "icao": "EHAM",
   "iata": "AMS",
   "magnetic_north": 0,

--- a/assets/airports/eidw.json
+++ b/assets/airports/eidw.json
@@ -1,7 +1,11 @@
 {
   "name": "Dublin Airport",
   "level": "easy",
-  "radio": "Dublin",
+  "radio": {
+    "twr": "Dublin Tower",
+    "app": "Dublin Approach",
+    "dep": "Dublin Departure"
+  },
   "icao": "EIDW",
   "iata": "DUB",
   "magnetic_north": 0,

--- a/assets/airports/engm.json
+++ b/assets/airports/engm.json
@@ -1,7 +1,11 @@
 {
   "name": "Oslo Gardermoen International Airport &#9983",
   "level": "easy",
-  "radio": "Oslo",
+  "radio": {
+    "twr": "Oslo Tower",
+    "app": "Oslo Approach",
+    "dep": "Oslo Departure"
+  },
   "icao": "ENGM",
   "iata": "OSL",
   "magnetic_north": -2.8,

--- a/assets/airports/kdbg.json
+++ b/assets/airports/kdbg.json
@@ -1,7 +1,11 @@
 {
   "name": "Debug airport",
   "level": "medium",
-  "radio": "Debug",
+  "radio": {
+    "twr": "Debug Tower",
+    "app": "Debug Approach",
+    "dep": "Debug Departure"
+  },
   "icao": "KDBG",
   "iata": "DBG",
   "magnetic_north": 0,

--- a/assets/airports/kjfk.json
+++ b/assets/airports/kjfk.json
@@ -1,7 +1,11 @@
 {
   "name": "John F Kennedy International Airport &#9983",
   "level": "medium",
-  "radio": "Kennedy",
+  "radio": {
+    "twr": "Kennedy Tower",
+    "app": "New York Approach",
+    "dep": "New York Departure"
+  },
   "icao": "KJFK",
   "iata": "JFK",
   "magnetic_north": 0,

--- a/assets/airports/klax.json
+++ b/assets/airports/klax.json
@@ -1,7 +1,11 @@
 {
   "name": "Los Angeles International Airport",
   "level": "medium",
-  "radio": "Los Angeles",
+  "radio": {
+    "twr": "Los Angeles Tower",
+    "app": "SoCal Approach",
+    "dep": "SoCal Departure"
+  },
   "icao": "KLAX",
   "iata": "LAX",
   "magnetic_north": 12.3,

--- a/assets/airports/kmsp.json
+++ b/assets/airports/kmsp.json
@@ -1,7 +1,11 @@
 {
   "name": "Minneapolis/St. Paul International Airport &#9983",
   "level": "hard",
-  "radio": "Minneapolis",
+  "radio": {
+    "twr": "Minneapolis Tower",
+    "app": "Minneapolis Approach",
+    "dep": "Minneapolis Departure"
+  },
   "icao": "KMSP",
   "iata": "MSP",
   "magnetic_north": 0.4,

--- a/assets/airports/ksan.json
+++ b/assets/airports/ksan.json
@@ -1,7 +1,11 @@
 {
   "name": "San Diego International Airport",
   "level": "easy",
-  "radio": "San Diego",
+  "radio": {
+    "twr": "Lindbergh Tower",
+    "app": "SoCal Approach",
+    "dep": "SoCal Departure"
+  },
   "icao": "KSAN",
   "iata": "SAN",
   "magnetic_north": 12.3,

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -3,8 +3,8 @@
   "level": "medium",
   "radio": {
     "twr": "San Francisco Tower",
-    "app": "SoCal Approach",
-    "dep": "SoCal Departure"
+    "app": "NorCal Approach",
+    "dep": "NorCal Departure"
   },
   "icao": "KSFO",
   "iata": "SFO",

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -1,7 +1,11 @@
 {
   "name": "San Francisco International Airport &#9983",
   "level": "medium",
-  "radio": "San Francisco",
+  "radio": {
+    "twr": "San Francisco Tower",
+    "app": "SoCal Approach",
+    "dep": "SoCal Departure"
+  },
   "icao": "KSFO",
   "iata": "SFO",
   "magnetic_north": 13.7,

--- a/assets/airports/loww.json
+++ b/assets/airports/loww.json
@@ -1,7 +1,11 @@
 {
   "name": "Vienna International Airport",
   "level": "medium",
-  "radio": "Vienna",
+  "radio": {
+    "twr": "Vienna Tower",
+    "app": "Vienna Approach",
+    "dep": "Vienna Departure"
+  },
   "icao": "LOWW",
   "iata": "VIE",
   "ctr_radius": 80,

--- a/assets/airports/ltba.json
+++ b/assets/airports/ltba.json
@@ -1,7 +1,11 @@
 {
   "name": "Atatürk International Airport &#9983",
   "level": "hard",
-  "radio": "Istanbul",
+  "radio": {
+    "twr": "Istanbul Tower",
+    "app": "Istanbul Approach",
+    "dep": "Istanbul Departure"
+  },
   "icao": "LTBA",
   "iata": "IST",
   "magnetic_north": 3.6,

--- a/assets/airports/saez.json
+++ b/assets/airports/saez.json
@@ -1,7 +1,11 @@
 {
   "name": "Aeropuerto Internacional Ministro Pistarini",
   "level": "medium",
-  "radio": "Ezeiza",
+  "radio": {
+    "twr": "Ezeiza Tower",
+    "app": "Ezeiza Approach",
+    "dep": "Ezeiza Departure"
+  },
   "icao": "SAEZ",
   "iata": "EZE",
   "magnetic_north": 0,

--- a/assets/airports/sbgl.json
+++ b/assets/airports/sbgl.json
@@ -1,7 +1,11 @@
 {
   "name": "Aeroporto Internacional Tom Jobim",
   "level": "beginner",
-  "radio": "Galeão",
+  "radio": {
+    "twr": "Galeão Tower",
+    "app": "Galeão Approach",
+    "dep": "Galeão Departure"
+  },
   "icao": "SBGL",
   "iata": "GIG",
   "magnetic_north": 0,

--- a/assets/airports/sbgr.json
+++ b/assets/airports/sbgr.json
@@ -1,7 +1,11 @@
 {
   "name": "Aeroporto Internacional de São Paulo/Guarulhos",
   "level": "beginner",
-  "radio": "Guarulhos",
+  "radio": {
+    "twr": "Guarulhos Tower",
+    "app": "Guarulhos Approach",
+    "dep": "Guarulhos Departure"
+  },
   "icao": "SBGR",
   "iata": "GRU",
   "magnetic_north": 0,

--- a/assets/airports/uudd.json
+++ b/assets/airports/uudd.json
@@ -1,7 +1,11 @@
 {
   "name": "Moscow Domodedovo Airport",
   "level": "easy",
-  "radio": "Domodedovo",
+  "radio": {
+    "twr": "Domodedovo Tower",
+    "app": "Domodedovo Approach",
+    "dep": "Domodedovo Departure"
+  },
   "icao": "UUDD",
   "iata": "DME",
   "magnetic_north": 10.8, 

--- a/assets/airports/vhhh.json
+++ b/assets/airports/vhhh.json
@@ -1,7 +1,11 @@
 { 
   "name": "Hong Kong Chep Lap Kok International Airport",
   "level": "medium",
-  "radio": "Hong Kong",
+  "radio": {
+    "twr": "Hong Kong Tower",
+    "app": "Hong Kong Approach",
+    "dep": "Hong Kong Departure"
+  },
   "icao": "VHHH",
   "iata": "HKG",
   "ctr_radius": 80,

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -764,7 +764,10 @@ var Aircraft=Fiber.extend(function() {
         var length = 2;
         callsign = callsign.substr(callsign.length - length);
       }
-      return airline_get(this.airline).callsign + " " + groupNumbers(callsign) + heavy;
+      var cs = airline_get(this.airline).callsign;
+      if(cs == "November") cs += " " + radio_spellOut(callsign) + heavy;
+      else cs += " " + groupNumbers(callsign) + heavy;
+      return cs;
     },
     getClimbRate: function() {
       var a = this.altitude;

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1031,17 +1031,18 @@ var Aircraft=Fiber.extend(function() {
     },
     runHeading: function(data) {
       var split     = data.split(" ");
-      var heading = "";
-      var direction = "";
+      var heading = null;
+      var direction = null;
+      var instruction = null;
       switch(split.length) {  //number of elements in 'data'
         case 1: 
           if(isNaN(parseInt(split))) {  //probably using shortKeys
             if(split[0][0] == "\u2BA2") { //using '<250' format
-              direction = "turn left heading ";
+              direction = "left";
               heading = split[0].substr(1); //remove shortKey
             }
             else if (split[0][0] == "\u2BA3") {  //using '>250' format
-              direction = "turn right heading ";
+              direction = "right";
               heading = split[0].substr(1); //remove shortKey
             }
             else if(split[0].substr(0,2).toLowerCase() == "fh") { //using 'fh250' format
@@ -1057,8 +1058,8 @@ var Aircraft=Fiber.extend(function() {
           break;
 
         case 2: //using 'turn r 250' format
-          if(split[0] === "l") direction = "turn left heading ";
-          else if (split[0] === "r" ) direction = "turn right heading ";
+          if(split[0] === "l") direction = "left";
+          else if (split[0] === "r" ) direction = "right";
           heading = parseInt(split[1]);
           break;
 
@@ -1081,11 +1082,12 @@ var Aircraft=Fiber.extend(function() {
         hold: false,
       });
 
-      if(!direction) direction  = "fly heading ";
+      if(direction) instruction = "turn " + direction + " heading ";
+      else instruction = "fly heading ";
 
       var readback = {
-        log: direction + heading_to_string(this.fms.currentWaypoint().heading),
-        say: direction + radio_heading(heading_to_string(this.fms.currentWaypoint().heading))
+        log: instruction + heading_to_string(this.fms.currentWaypoint().heading),
+        say: instruction + radio_heading(heading_to_string(this.fms.currentWaypoint().heading))
       };
       return ['ok', readback];
     },

--- a/assets/scripts/speech.js
+++ b/assets/scripts/speech.js
@@ -10,11 +10,30 @@ function speech_init() {
   }
 }
 
-function speech_say(textToSay) {
+function speech_say(sentence) {
   if(prop.speech.synthesis != null && prop.speech.enabled) {
-    // Split numbers into individual digits e.g. Speedbird 666 -> Speedbird 6 6 6
-    textToSay = textToSay.replace(/[0-9]/g, "$& ").replace(/\s0/g, " zero");
-    prop.speech.synthesis.speak(new SpeechSynthesisUtterance(textToSay));
+    var textToSay = "";
+    for(var i=0; i<sentence.length; i++) {
+      switch(sentence[i].type) {
+        case "callsign":
+          textToSay += " " + sentence[i].content.getRadioCallsign() + " "; break;
+        case "altitude":
+          textToSay += " " + radio_altitude(sentence[i].content) + " "; break;
+        case "speed": case "heading":
+          textToSay += " " + radio_heading(sentence[i].content) + " "; break;
+        case "text":
+          textToSay += " " + sentence[i].content + " "; break;
+        default:
+          break;
+      }
+    }
+
+    var utterance = new SpeechSynthesisUtterance(textToSay); // make the object
+    utterance.lang = "en-US"; // set the language
+    utterance.voice = prop.speech.synthesis.getVoices().filter(function(voice) {
+      return voice.name == 'Google US English'; })[0];   //set the voice
+    utterance.rate = 1.125; // speed up just a touch
+    prop.speech.synthesis.speak(utterance);  // say the words
   }
 }
 

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -195,7 +195,7 @@ function ui_log(message) {
     }, 10000);
   }, 3, window, html);
 
-  speech_say(message);
+  // speech_say(message);
 
 //  console.log("MESSAGE: " + message);
 }

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -246,6 +246,24 @@ var radio_names = {
   7:"seven",
   8:"eight",
   9:"niner",
+  10:"ten",
+  11:"eleven",
+  12:"twelve",
+  13:"thirteen",
+  14:"fourteen",
+  15:"fifteen",
+  16:"sixteen",
+  17:"seventeen",
+  18:"eighteen",
+  19:"nineteen",
+  20:"twenty",
+  30:"thirty",
+  40:"fourty",
+  50:"fifty",
+  60:"sixty",
+  70:"seventy",
+  80:"eighty",
+  90:"ninety",
   a:"alpha",
   b:"bravo",
   c:"charlie",
@@ -293,6 +311,37 @@ radio_runway_names.l = "left";
 radio_runway_names.c = "center";
 radio_runway_names.r = "right";
 
+function groupNumbers(callsign) {
+  var getGrouping = function(groupable) {
+    var digit1 = groupable[0];
+    var digit2 = groupable[1];
+    if(digit1 == 0) {
+      if(digit2 == 0) return "hundred";
+      else return radio_names[digit1] + " " + radio_names[digit2];    // just digits (eg 'zero seven')
+    }
+    else if(digit1 == 1) return radio_names[groupable];         // exact number (eg 'seventeen')
+    else if(digit1 >= 2) {
+      if(digit2 == 0) return radio_names[(digit1+"0")]; // to avoid 'five twenty zero'
+      else return radio_names[(digit1+"0")] + " " + radio_names[digit2]; // combo number (eg 'fifty one')
+    }
+    else return radio_names[digit1] + " " + radio_names[digit2];
+  }
+
+  if(!/^\d+$/.test(callsign)) { // if contains more than just numbers (eg '117KS')
+    var s = [];
+    for (var k in callsign) { s.push(radio_names[k]); } // one after another (eg 'one one seven kilo sierra')
+    return s.join(" ");
+  }
+  else switch (callsign.length) {
+    case 0: return callsign; break;
+    case 1: return radio_names[callsign]; break;
+    case 2: return getGrouping(callsign); break;
+    case 3: return radio_names[callsign[0]] + " " + getGrouping(callsign.substr(1)); break;
+    case 4: return getGrouping(callsign.substr(0,2)) + " " + getGrouping(callsign.substr(2)); break;
+    default: return callsign;
+  }
+}
+
 function radio_spellOut(input) {
   input = input + "";
   input = input.toLowerCase();
@@ -315,21 +364,47 @@ function radio_runway(input) {
   return s.join(" ");
 }
 
-function radio_cardinalDir(input) {
-  input = input + "";
-  input = input.toLowerCase();
+function radio_heading(heading) {
+  var str = heading.toString();
+  var hdg = [];
+  if(str) {
+    if(str.length == 1) return "zero zero " + radio_names[str];
+    else if(str.length == 2) return "zero " + radio_names[str[0]] + " " + radio_names[str[1]];
+    else return radio_names[str[0]] + " " + radio_names[str[1]] + " " + radio_names[str[2]];
+  } else return heading;
+}
+
+// function radio_cardinalDir(input) {
+//   input = input + "";
+//   input = input.toLowerCase();
+//   var s = [];
+//   for(var i=0;i<input.length;i++) {
+//     var c = radio_cardinalDir_names[input[i]];
+//     if(c) s.push(c);
+
+function radio_altitude(altitude) {
+  var alt_s = altitude.toString();
   var s = [];
-  for(var i=0;i<input.length;i++) {
-    var c = radio_cardinalDir_names[input[i]];
-    if(c) s.push(c);
+  if(altitude >= 18000) {
+    s.push("flight level", radio_names[alt_s[0]], radio_names[alt_s[1]], radio_names[alt_s[2]]);
   }
+  else if(altitude >= 10000) {
+    s.push(radio_names[alt_s[0]], radio_names[alt_s[1]], "thousand");
+  }
+  else if(altitude >= 1000) {
+    s.push(radio_names[alt_s[0]], "thousand");
+  }
+  else if(altitude >= 100) {
+    s.push(radio_names[alt_s[0]], "hundred");
+  }
+  else return altitude;
   return s.join(" ");
 }
 
 function radio_trend(category, measured, target) {
   var CATEGORIES = {
-    "altitude": ["descend to", "climb to",  "maintaining"],
-    "speed":    ["set speed",  "set speed", "maintaining"]
+    "altitude": ["descend and maintain", "climb and maintain",  "maintain"],
+    "speed":    ["reduce speed to",  "increase speed to", "maintain present speed of"]
   };
   if(measured > target) return CATEGORIES[category][0];
   if(measured < target) return CATEGORIES[category][1];

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -230,8 +230,10 @@ function average() {
 }
 
 function heading_to_string(heading) {
-  heading = round(mod(degrees(heading), 360));
-  if(heading == 0) heading = 360;
+  heading = round(mod(degrees(heading), 360)).toString();
+  if(heading == "0") heading = "360";
+  if(heading.length == 1) heading = "00" + heading;
+  if(heading.length == 2) heading = "0" + heading;
   return heading;
 }
 

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -394,9 +394,15 @@ function radio_altitude(altitude) {
   }
   else if(altitude >= 10000) {
     s.push(radio_names[alt_s[0]], radio_names[alt_s[1]], "thousand");
+    if(!(altitude % (Math.floor(altitude/1000)*1000) == 0)) {
+      s.push(radio_names[alt_s[2]], "hundred");
+    }
   }
   else if(altitude >= 1000) {
     s.push(radio_names[alt_s[0]], "thousand");
+    if(!(altitude % (Math.floor(altitude/1000)*1000) == 0)) {
+      s.push(radio_names[alt_s[1]], "hundred");
+    }
   }
   else if(altitude >= 100) {
     s.push(radio_names[alt_s[0]], "hundred");

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -344,17 +344,6 @@ function groupNumbers(callsign) {
   }
 }
 
-function radio_spellOut(input) {
-  input = input + "";
-  input = input.toLowerCase();
-  var s = [];
-  for(var i=0;i<input.length;i++) {
-    var c = radio_names[input[i]];
-    if(c) s.push(c);
-  }
-  return s.join(" ");
-}
-
 function radio_runway(input) {
   input = input + "";
   input = input.toLowerCase();

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -374,13 +374,15 @@ function radio_heading(heading) {
   } else return heading;
 }
 
-// function radio_cardinalDir(input) {
-//   input = input + "";
-//   input = input.toLowerCase();
-//   var s = [];
-//   for(var i=0;i<input.length;i++) {
-//     var c = radio_cardinalDir_names[input[i]];
-//     if(c) s.push(c);
+function radio_spellOut(alphanumeric) {
+  var str = alphanumeric.toString();
+  var arr = [];
+  if(!str) return;
+  for(var i=0; i<str.length; i++) {
+    arr.push(radio_names[str[i]]);
+  }
+  return arr.join(" ");
+}
 
 function radio_altitude(altitude) {
   var alt_s = altitude.toString();
@@ -409,11 +411,6 @@ function radio_trend(category, measured, target) {
   if(measured > target) return CATEGORIES[category][0];
   if(measured < target) return CATEGORIES[category][1];
   return CATEGORIES[category][2];
-}
-
-function radio_altitude(alt) {
-  if(alt >= 18000) return "flight level " + round(alt/100).toString();
-  else return alt.toString();
 }
 
 function getCardinalDirection(angle) {


### PR DESCRIPTION
Changes various pieces of phraseology to correct FAA phraseology (for the most part). A lot of work done for making the speech synthesis sound good without the need for the ui_log to display messages like `United six niner four, runway two eight right, cleared for takeoff`, and instead shows `UAL694, runway 28L, cleared for takeoff`, but reads it aloud correctly. You'll also notice that aircraft will call up to the different facilities we simulate based on the situation, eg. a departure will say `San Francisco Tower, UAL394, holding short of 28R`, and an arrival will say `NorCal Approach, BAW588 with you at 10000`. This reflects reality, as the names of the approach, departure, and tower facilities are not always the same, as pictured below.

![image](https://cloud.githubusercontent.com/assets/5103735/12635897/16619306-c556-11e5-9fbb-0a8b76b53b7c.png)

PS - Sorry to the reviewer if the code in this PR is a bit scattered and difficult to rummage through. I tried to make it presentable but there were just a lot of tiny changes in a whole bunch of different places.

Give her a listen! :smiley: [http://erikquinn.github.io/atc](erikquinn.github.io/atc)
