### PR TITLE
Added Magnetic North to all airports

### DIFF
--- a/assets/airports/eddh.json
+++ b/assets/airports/eddh.json
@@ -8,7 +8,7 @@
   },
   "icao": "EDDH",
   "iata": "HAM",
-  "magnetic_north": 0,
+  "magnetic_north": 1,
   "ctr_radius": 80,
   "position": ["N53d37m49.00", "E9d59m18.00"],
   "rr_radius_nm": 5.0,
@@ -86,7 +86,7 @@
       "WSR": ["DH002", "ANEXI", "WSR"]
     },
     "destinations": [
-      56, 90, 122, 207, 248, 355
+      55, 89, 121, 206, 247, 354
     ],
     "type": "random",
     "frequency": 15

--- a/assets/airports/eglc.json
+++ b/assets/airports/eglc.json
@@ -8,7 +8,7 @@
   },
   "icao": "EGLC",
   "iata": "LCY",
-  "magnetic_north": 0.14,
+  "magnetic_north": -0.9,
   "ctr_radius": 80,
   "position": ["N51d30m19.08", "E0d3m19.00"],
   "rr_radius_nm": 5.0,

--- a/assets/airports/eglc.json
+++ b/assets/airports/eglc.json
@@ -8,7 +8,7 @@
   },
   "icao": "EGLC",
   "iata": "LCY",
-  "magnetic_north": 0,
+  "magnetic_north": 0.14,
   "ctr_radius": 80,
   "position": ["N51d30m19.08", "E0d3m19.00"],
   "rr_radius_nm": 5.0,
@@ -84,7 +84,7 @@
       "COMPTON": ["BPK", "HEN", "CPT"]
     },
     "destinations": [
-      64, 113, 135, 275
+      63, 114, 135, 275
     ],
     "type": "random",
     "offset": 0,

--- a/assets/airports/egll.json
+++ b/assets/airports/egll.json
@@ -8,7 +8,7 @@
   },
   "icao": "EGLL",
   "iata": "LHR",
-  "magnetic_north": 0,
+  "magnetic_north": 0.14,
   "ctr_radius": 80,
   "position": ["N51d28m16.41", "W0d27m41.19"],
   "rr_radius_nm": 5.0,

--- a/assets/airports/egll.json
+++ b/assets/airports/egll.json
@@ -3,8 +3,8 @@
   "level": "hard",
   "radio": {
     "twr": "Heathrow Tower",
-    "app": "Heathrow Approach",
-    "dep": "Heathrow Departure"
+    "app": "Heathrow Director",
+    "dep": "Heathrow Director"
   },
   "icao": "EGLL",
   "iata": "LHR",

--- a/assets/airports/egll.json
+++ b/assets/airports/egll.json
@@ -8,7 +8,7 @@
   },
   "icao": "EGLL",
   "iata": "LHR",
-  "magnetic_north": 0.14,
+  "magnetic_north": -1,
   "ctr_radius": 80,
   "position": ["N51d28m16.41", "W0d27m41.19"],
   "rr_radius_nm": 5.0,
@@ -297,7 +297,7 @@
       "MAY": ["EPM", "MAY", "SFD"]
     },
     "destinations": [
-      63, 104, 150, 227, 275, 335
+      64, 105, 151, 228, 276, 336
     ],
     "type": "random",
     "offset": 0,

--- a/assets/airports/eidw.json
+++ b/assets/airports/eidw.json
@@ -8,7 +8,7 @@
   },
   "icao": "EIDW",
   "iata": "DUB",
-  "magnetic_north": 0,
+  "magnetic_north": -4,
   "ctr_radius": 80,
   "position": ["N53d25m17.00", "W6d16m12.00"],
   "rr_radius_nm": 5.0,
@@ -119,7 +119,7 @@
       "ROTEV": ["DW931", "LEMTA", "ROTEV"]
     },
     "destinations": [
-      85, 162, 323, 10, 106, 200, 251, 285
+      89, 166, 327, 14, 110, 204, 255, 289
     ],
     "type": "random",
     "offset": 0,

--- a/assets/airports/kjfk.json
+++ b/assets/airports/kjfk.json
@@ -8,7 +8,7 @@
   },
   "icao": "KJFK",
   "iata": "JFK",
-  "magnetic_north": 0,
+  "magnetic_north": -13.1,
   "ctr_radius": 80,
   "position": ["N40.6328889", "W73.7713889"],
   "rr_radius_nm": 5.0,

--- a/assets/airports/loww.json
+++ b/assets/airports/loww.json
@@ -8,6 +8,7 @@
   },
   "icao": "LOWW",
   "iata": "VIE",
+  "magnetic_north": 4,
   "ctr_radius": 80,
   "position": ["N48d6m37.07", "E16d34m10.92"],
   "rr_radius_nm": 5.0,
@@ -116,7 +117,7 @@
       "SITNI": ["WW101", "WW275", "WW178", "SITNI"]
     },
     "destinations": [
-      13, 103, 179, 235, 265, 315
+      9, 99, 175, 231, 261, 311
     ],
     "type": "random",
     "offset": 0,

--- a/assets/airports/saez.json
+++ b/assets/airports/saez.json
@@ -8,7 +8,7 @@
   },
   "icao": "SAEZ",
   "iata": "EZE",
-  "magnetic_north": 0,
+  "magnetic_north": -8,
   "ctr_radius": 102,
   "position": ["S34d49m19.92", "W58d32m8.8"],
   "rr_radius_nm": 5.0,
@@ -112,7 +112,7 @@
       "BELGRANO": ["EZE12", "EZE97", "EZE70", "GBE"]
     },
     "destinations": [
-      80, 177, 278, 325, 360
+      8, 88, 185, 285, 334
     ],
     "type": "random",
     "offset": 0,

--- a/assets/airports/sbgl.json
+++ b/assets/airports/sbgl.json
@@ -8,7 +8,7 @@
   },
   "icao": "SBGL",
   "iata": "GIG",
-  "magnetic_north": 0,
+  "magnetic_north": -23,
   "ctr_radius": 115,
   "position": ["S22.813391", "W43.249464"],
   "rr_radius_nm": 5.0,
@@ -122,7 +122,7 @@
       ["FAB", 1]
     ],
     "destinations": [
-      40, 70, 205, 240, 350
+      63, 93, 130, 228, 263, 373
     ],
     "frequency": [1, 4.5]
   },

--- a/assets/airports/sbgr.json
+++ b/assets/airports/sbgr.json
@@ -8,7 +8,7 @@
   },
   "icao": "SBGR",
   "iata": "GRU",
-  "magnetic_north": 0,
+  "magnetic_north": -21,
   "ctr_radius": 80,
   "position": ["S23.253020", "W46.265706"],
   "rr_radius_nm": 5.0,
@@ -111,7 +111,7 @@
       "DORLU": ["BCO", "VULET", "DORLU"]
     },
     "destinations": [
-      72, 83, 355, 225, 253, 272
+      96, 104, 376, 246, 274, 293
     ],
     "frequency": [1, 15]
   },

--- a/assets/airports/vhhh.json
+++ b/assets/airports/vhhh.json
@@ -8,6 +8,7 @@
   },
   "icao": "VHHH",
   "iata": "HKG",
+  "magnetic_north": -2,
   "ctr_radius": 80,
   "position": ["N22d18m32.11", "E113d54m52.57"],
   "rr_radius_nm": 5.0,
@@ -333,7 +334,7 @@
       "PECAN": ["PRAWN", "RUMSY", "TUNNA", "TITAN", "PECAN"]
     },
     "destinations": [
-      128, 135, 170, 357
+      130, 137, 172, 359
     ],
     "type": "random",
     "offset": 0,


### PR DESCRIPTION
Added magnetic north to all airports and changed departure destinations respectively:
-Some airports had magnetic north already, these remained unchanged.
-SID "AGUA" at SBGL didn't have a departure destination, it was added.
-KJFK has no SID's, departure destinations unchanged.
