### PR TITLE
Localizer interception

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1696,7 +1696,7 @@ var Aircraft=Fiber.extend(function() {
         if ((abs(this.altitude - glideslope_altitude) < glideslope_window)
             && (abs(offset_angle) < radians(10))
             && (offset[1] < ils)) {
-          if(this.mode != "landing") {
+          if(abs(offset[0]) < 0.05 && this.mode != "landing") {
             this.mode = "landing";
             if (!this.projected && (abs(angle_offset(this.fms.currentWaypoint().heading,
                   radians(parseInt(this.fms.currentWaypoint().runway.substr(0,2))*10))) > radians(30))) {
@@ -1736,7 +1736,7 @@ var Aircraft=Fiber.extend(function() {
             speech_say([ {type:"callsign", content:this}, {type:"text", content:" going around"} ])
             prop.game.score.abort.landing += 1;
           }
-        } else {
+        } else if(this.altitude >= 300) {
           this.target.heading = this.fms.currentWaypoint().heading;
           this.target.turn = this.fms.currentWaypoint().turn;
         }

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1698,12 +1698,10 @@ var Aircraft=Fiber.extend(function() {
             && (offset[1] < ils)) {
           if(this.mode != "landing") {
             this.mode = "landing";
-            if (!this.projected &&
-                (abs(angle_offset(this.fms.currentWaypoint().heading, angle)) > radians(30)))
-            {
-              ui_log(true,
-                     this.getRadioCallsign() +
-                       " landing intercept vector was greater than 30 degrees");
+            if (!this.projected && (abs(angle_offset(this.fms.currentWaypoint().heading,
+                  radians(parseInt(this.fms.currentWaypoint().runway.substr(0,2))*10))) > radians(30))) {
+              ui_log(true, this.getRadioCallsign() +
+                      " approach course intercept angle was greater than 30 degrees");
               prop.game.score.violation += 1;
             }
             this.updateStrip();


### PR DESCRIPTION
Resolves #375 and also fixes another issue I never wrote up an issue for... when a/c are given a heading, they are expected to fly that heading until joining the localizer. In the sim, they kind of just fly it until they get close-ish to the localizer and then turn TOWARD the approach course, which would not be allowable, and makes it difficult to control the sequence because you are forced to withhold approach clearances to prevent the undesirable behavior. Now they will actually stay on the heading until they need to turn onto the localizer.

See pictures below. Both aircraft were assigned a heading of 275, which they have been flying for a few miles. You'll notice how EL turns left to a sharper intercept angle, while the speedbird stays on the assigned heading all the way to the localizer.

before:
![image](https://cloud.githubusercontent.com/assets/5103735/13134265/5b8ba5a2-d5d2-11e5-817a-ded3291735a5.png)

after: 
![image](https://cloud.githubusercontent.com/assets/5103735/13134234/e48a9972-d5d1-11e5-80e0-58bdaff32d9d.png)
