### PR TITLE
Clear Runway After Crash

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -108,6 +108,18 @@ zlsa.atc.Conflict = Fiber.extend(function() {
         prop.game.score.hit += 1;
         this.aircraft[0].hit = true;
         this.aircraft[1].hit = true;
+
+        // If either are in runway queue, remove them from it
+        for(var i in airport_get().runways) {
+          var rwy = airport_get().runways[i];
+          var queue = rwy.waiting[0];
+          for(var j in queue) {
+            if(queue[j] == this.aircraft[0])
+              rwy.removeQueue(this.aircraft[0], rwy, true);
+            if(queue[j] == this.aircraft[1])
+              rwy.removeQueue(this.aircraft[1], rwy, true);
+          }
+        }
       }
     },
 

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -570,15 +570,14 @@ var Runway=Fiber.extend(function(base) {
       this.waiting      = [[], []];
 
       this.parse(options);
-
     },
     addQueue: function(aircraft, end) {
       end = this.getEnd(end);
       this.waiting[end].push(aircraft);
     },
-    removeQueue: function(aircraft, end) {
+    removeQueue: function(aircraft, end, force) {
       end = this.getEnd(end);
-      if(this.waiting[end][0] == aircraft) {
+      if(this.waiting[end][0] == aircraft || force) {
         this.waiting[end].shift(aircraft);
         if(this.waiting[end].length >= 1) {
           this.waiting[end][0].moveForward();
@@ -604,7 +603,6 @@ var Runway=Fiber.extend(function(base) {
       var offset = [0, 0];
       offset[0]  = (-cos(this.angle) * position[0]) + (sin(this.angle) * position[1]);
       offset[1]  = ( sin(this.angle) * position[0]) + (cos(this.angle) * position[1]);
-//      offset[1] *= -1;
 
       if(end == 0) {
         offset = vscale(offset, -1);
@@ -614,7 +612,6 @@ var Runway=Fiber.extend(function(base) {
         offset[1] -= this.length / 2;
       }
       return offset;
-
     },
     getAngle: function(end) {
       end = this.getEnd(end);


### PR DESCRIPTION
Resolves #105 and #353.

When an aircraft who is still in the takeoff queue for a given `runway`, and has a collision with another aircraft, both are removed from the _game_, but the departure is not removed from the runway's queue. This fixes that. Now if a collision takes place, little cyber ninja monkeys scurry out onto the tarmac and sweep up all the crash debris so the next departure can get on with its life (they're fast too-- the runway is available within milliseconds!) 

Highly technical explanation in emoji speak:
:boom: :airplane: :boom: :fire: :fire_engine: :heavy_plus_sign: :monkey: :arrow_right: :airplane: :+1: 

Shout out to @harp71 who figured out how to reproduce it. Made it pretty easy to fix, so thank you!

---

Demo: [http://erikquinn.github.io/atc/b/sweep-the-crash-debris/](http://erikquinn.github.io/atc/b/sweep-the-crash-debris/)
