### PR TITLE
Add logic for building alphanumeric airline callsigns

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -940,7 +940,7 @@ var Aircraft=Fiber.extend(function() {
       }
       var cs = airline_get(this.airline).callsign;
       if(cs == "November") cs += " " + radio_spellOut(callsign) + heavy;
-      else cs += " " + groupNumbers(callsign) + heavy;
+      else cs += " " + groupNumbers(callsign, this.airline) + heavy;
       return cs;
     },
     getClimbRate: function() {


### PR DESCRIPTION
Resolves #412.

Previously, I was under the assumption that GA aircraft (those whose callsigns are simply their tail numbers) were the only ones who would have an alphanumeric flight number, and that all airlines take the format 'AAL' (eg airline identifier) followed by '####' (eg some numbers that won't be letters). This is apparently not how it's _always_ done though; there are sometimes things like 'BAW547A', 'BER70WQ', etc. This updates the logic to handle those mixed alphanumeric callsigns, and does so the hard way: by actually reading through each digit and pronouncing it based on the context of what surrounds it, and grouping as appropriate, where appropriate, like we humans would.

Demo: http://erikquinn.github.io/atc/b/alphanumericAirlines/
