### PR TITLE
Holding patterns

### DIFF
--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -177,6 +177,14 @@ function radians(degrees) {
   return (degrees/360)*(Math.PI*2);
 }
 
+/** Constrains an angle to within 0 --> Math.PI*2
+ */
+function fix_angle(radians) {
+  while(radians > Math.PI*2) radians -= Math.PI*2;
+  while(radians < 0) radians += Math.PI*2;
+  return radians;
+}
+
 function choose(l) {
   return l[Math.floor(Math.random()*l.length)];
 }


### PR DESCRIPTION
Resolves #373.

![image](https://cloud.githubusercontent.com/assets/5103735/14504547/ed057e9e-017a-11e6-952c-40435946cd10.png)

Implements proper holding patterns to replace the continuous-turn circles. Aircraft may now be told to proceed direct to a fix and hold there, along their inbound course. Alternatively, the same old same old also works, so you can tell them to `hold`, and they'll hold over their present position. If you like, you can also specify the turn direction with either `left` or `right` (default), as well as the leg length (only expressable in _minutes_ at this time), formatted like `1min` (default) or `3min`.

Examples:
- `hold`
- `hold left`
- `hold right`1min` (redundant, same as first)
- `hold left faith`
- `hold swels 3min` (long legs)

Note that this is not done entirely "properly"... they just make repeating 180 degree turns in the specified direction, and do not correct for wind. However, in anything other than a gale-force storm, I've observed no appreciable difference, and it seems to do the job well enough that I don't see a reason to spend time to get it to crab into the wind during the hold, though this is what a real pilot would have to do. But it looks a heck of a lot better than what we've got now! :smile:

Test: [erikquinn.github.io/atc](http://erikquinn.github.io/atc)
