### PR TITLE
Hotfix for #431

### DIFF
--- a/assets/scripts/airline.js
+++ b/assets/scripts/airline.js
@@ -131,8 +131,8 @@ zlsa.atc.Airline = Fiber.extend(function() {
 
 function airline_init() {
   // 1990' Airlines
-	  airline_load("PAA");
-	  airline_load("TWA");
+  airline_load("PAA");
+  airline_load("TWA");
 
   // American
   airline_load("UAL");
@@ -142,16 +142,23 @@ function airline_init() {
   airline_load("ACA");
   airline_load("AMX");
   airline_load("DAL");
-  airline_load("EZY");
   airline_load("FASTGA");
   airline_load("FLG");
   airline_load("GWI");
   airline_load("JBU");
   airline_load("KLC");
   airline_load("LIGHTGA");
-  airline_load("FASTGA");
   airline_load("VRD");
   airline_load("SWA");
+  airline_load("ASA");
+  airline_load("ASQ");
+  airline_load("GJS");
+  airline_load("JIA");
+  airline_load("KAP");
+  airline_load("PDT");
+  airline_load("RPA");
+  airline_load("TCF");
+  airline_load("ENY");
 
   // European
   airline_load("AEA");
@@ -164,16 +171,16 @@ function airline_init() {
   airline_load("SAS");
   airline_load("SCX");
   airline_load("THY");
-  airline_load("UAL");
   airline_load("VIR");
-  
-  //Europe
-	airline_load("AEA");
 	airline_load("AFR");
 	airline_load("AZA");
 	airline_load("IBE");
-  airline_load("DLH");
   airline_load("KLM");
+  airline_load("AUA");
+  airline_load("RYR");
+  airline_load("SWR");
+  airline_load("BCY");
+  airline_load("BWA");
   
   // South American
   airline_load("ONE");
@@ -191,7 +198,6 @@ function airline_init() {
   airline_load("SBI");
   airline_load("SVR");
   airline_load("TYA");
-  airline_load("ASA");
   airline_load("EVA");
   airline_load("KAL");
   airline_load("JAL");
@@ -199,7 +205,6 @@ function airline_init() {
 
   // Middle East
   airline_load("ETD");
-  airline_load("THY");
   airline_load("UAE");
 
   // Asian
@@ -208,6 +213,7 @@ function airline_init() {
   airline_load("CSN");
   airline_load("HDA");
   airline_load("CCA");
+  airline_load("TSO");
 
   // Cargo Airlines
   airline_load("FDX");
@@ -218,6 +224,9 @@ function airline_init() {
   airline_load("RFF");
   airline_load("FAB");
   airline_load("USAF");
+
+  // General Aviation
+  airline_load("AIRTAXI");
 }
 
 function airline_load(icao) {


### PR DESCRIPTION
Add calls to load the new airlines from #431.

Fixes an issue that was causing the game to crash whenever an aircraft tried to spawn who was from the new airlines, because the airlines were not told to load at initiation time of the game. That is fixed here, and therefore resolves #444.
