### PR TITLE
Strip coloring while "self-guided"

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -365,9 +365,9 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
       this.addWaypoint();
       this.fp.altitude = clamp(1000, options.model.ceiling, 60000);
       if(options.aircraft.category == "arrival") 
-        this.fp.route.push(airport_get().icao,"KDBG");
-      else if(options.aircraft.category == "departure") 
         this.fp.route.push("KDBG",airport_get().icao);
+      else if(options.aircraft.category == "departure") 
+        this.fp.route.push(airport_get().icao,"KDBG");
     },
 
     parse: function(options) {
@@ -724,8 +724,8 @@ var Aircraft=Fiber.extend(function() {
 
       this.position_history = [];
 
-      this.category    = "arrival"; // or "departure"
-      this.mode        = "cruise";  // "apron", "taxi", "waiting", "takeoff", "cruise", or "landing"
+      this.category = options.category; // or "departure"
+      this.mode     = "cruise";  // "apron", "taxi", "waiting", "takeoff", "cruise", or "landing"
       // where:
       // - "apron" is the initial status of a new departing plane. After
       //   the plane is issued the "taxi" command, the plane transitions to

--- a/assets/style/strip.css
+++ b/assets/style/strip.css
@@ -56,17 +56,17 @@
   font-style: italic;
 }
 
+.strip .lookingGood {
+  color: #88c790;
+}
+
+.strip .allSet {
+  color: #5d987b;
+}
+
 .strip .hold {
   color: #f76;
   font-style: italic;
-}
-
-.strip .taxi {
-/*  color: #f8e;*/
-}
-
-.strip .waiting {
-/*  color: #7f6;*/
 }
 
 .strip .altitude {
@@ -78,7 +78,7 @@
 
 .strip .destination {
   text-align: center;
-  color: #8cf;
+  /*color: #8cf;*/
 
   position: absolute;
   padding-right: 5px;


### PR DESCRIPTION
Resolves #182.

In #182, @MaicomMR suggested a change to green colored text in the strip when aircraft have locked on the ILS, as opposed to the current behavior (blue), since that was very misleading in the fact that it matched the color of departures.

Taking it a step further, here's what I propose:
- Departing a/c that are on the ground and have everything they need to takeoff (altitude, flightplan clearance) will have BLUE text
- Dep/Arr a/c that need additional work (don't have a route clearance, don't have an altitude assigned, need to be vectored to the ILS) will have WHITE text
- Arriving a/c that have been _cleared_ for the ILS, but haven't yet captured it will be strong GREEN.
- Dep/Arr a/c that are actively following a SID to their destination or established on an instrument approach will be faint GREEN.

I've actually found these colors to  be very helpful, as the "faint green" is a very passive shade that kind of fades into the background, and your attention is naturally drawn to those brighter strips that actually need something. This way, you can glance at the strip bay, and see that you have a new departure, because it's blue and white, not green. I've changed the coloring plan a bunch of time, so have a look, and further suggestions on alterations are encouraged! Let me know what you think would be the best combination of practicality and good looks.

![strip colors](https://cloud.githubusercontent.com/assets/5103735/14560578/55462920-02d6-11e6-8460-0942f33198f5.PNG)

Test: [erikquinn.github.io/atc/b/strips-while-on-ils](http://erikquinn.github.io/atc/b/strips-while-on-ils)
