### PR TITLE
Set score 0 when loading new airport

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -1095,6 +1095,8 @@ function airport_set(icao) {
 
   $('.toggle-terrain').toggle(
     !$.isEmptyObject(prop.airport.current.terrain));
+
+  game_reset_score();
 }
 
 function airport_get(icao) {

--- a/assets/scripts/game.js
+++ b/assets/scripts/game.js
@@ -142,6 +142,20 @@ function game_get_weighted_score() {
   return score;
 }
 
+function game_reset_score() {
+  prop.game.score.abort = {"landing": 0, "taxi": 0};
+  prop.game.score.arrival = 0;
+  prop.game.score.departure = 0;
+  prop.game.score.failed_arrival = 0;
+  prop.game.score.failed_departure = 0;
+  prop.game.score.hit = 0;
+  prop.game.score.restrictions = 0;
+  prop.game.score.violation = 0;
+  prop.game.score.warning = 0;
+  prop.game.score.windy_landing = 0;
+  prop.game.score.windy_takeoff = 0;
+}
+
 function game_timewarp_toggle() {
   if(prop.game.speedup == 5) {
     prop.game.speedup = 1;


### PR DESCRIPTION
Resolves #445 by resetting the score to 0 whenever the `airport_set()` function is called (this is the function that is called when a new airport is loaded).

Test: [erikquinn.github.io/atc/b/reset-score-on-new-airport](http://erikquinn.github.io/atc/b/reset-score-on-new-airport)
