### PR TITLE
Polygonal airspace boundaries

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -2196,10 +2196,15 @@ var Aircraft=Fiber.extend(function() {
       this.radial = vradial(this.position);
       if (this.radial < 0) this.radial += Math.PI*2;
 
-      var inside = (this.distance <= airport_get().ctr_radius &&
-                    this.altitude <= airport_get().ctr_ceiling);
-      if (inside != this.inside_ctr)
-        this.crossBoundary(inside);
+      if(airport_get().perimeter) { // polygonal airspace boundary
+        var inside = point_in_area(this.position, airport_get().perimeter);
+        if (inside != this.inside_ctr) this.crossBoundary(inside);
+      }
+      else {  // simple circular airspace boundary
+        var inside = (this.distance <= airport_get().ctr_radius &&
+                      this.altitude <= airport_get().ctr_ceiling);
+        if (inside != this.inside_ctr) this.crossBoundary(inside); 
+      }
     },
     updateWarning: function() {
       // Ignore other aircraft while taxiing

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -726,6 +726,12 @@ var Airport=Fiber.extend(function() {
 
         // airspace perimeter (assumed to be first entry in data.airspace)
         this.perimeter = areas[0];
+
+        // change ctr_radius to point along perimeter that's farthest from rr_center
+        var pos = new Position(this.perimeter.poly[0].position, this.position, this.magnetic_north);
+        var len = nm(vlen(vsub(pos.position, this.position.position)));
+        var apt = this;
+        this.ctr_radius = Math.max(...$.map(this.perimeter.poly, function(v) {return vlen(vsub(v.position,new Position(apt.rr_center, apt.position, apt.magnetic_north).position));}));
       }
       
       if(data.runways) {

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -657,6 +657,8 @@ var Airport=Fiber.extend(function() {
       this.metadata = {
         rwy: {}
       };
+      this.airspace = null; // array of areas under this sector's control. If null, draws circle with diameter of 'ctr_radius'
+      this.perimeter= null; // area outlining the outermost lateral airspace boundary. Comes from this.airspace[0]
 
       this.timeout  = {
         runway: null,
@@ -707,6 +709,23 @@ var Airport=Fiber.extend(function() {
 
       if (this.has_terrain) {
         this.loadTerrain();
+      }
+
+      if(data.airspace) { // create 3d polygonal airspace
+        var areas = [];
+        for(var i=0; i<data.airspace.length; i++) { // for each area
+          var positions = [];
+          for(var j=0; j<data.airspace[i].poly.length; j++) {  // for each point
+            positions.push(new Position(data.airspace[i].poly[j],
+                                        this.position, this.magnetic_north));
+          }
+          areas.push(new Area(positions, data.airspace[i].floor*100,
+            data.airspace[i].ceiling*100, data.airspace[i].airspace_class));
+        }
+        this.airspace = areas;
+
+        // airspace perimeter (assumed to be first entry in data.airspace)
+        this.perimeter = areas[0];
       }
       
       if(data.runways) {

--- a/assets/scripts/base.js
+++ b/assets/scripts/base.js
@@ -131,3 +131,33 @@ var Position=Fiber.extend(function() {
     },
   };
 });
+
+/** An enclosed region defined by a series of Position objects and an altitude range
+ ** @param {array} poly - series of Position objects that outline the shape
+ **                Note: DO NOT repeat the origin to 'close' the shape. Unnecessary.
+ ** @param {number} floor - (optional) altitude of bottom of area, in hundreds of feet
+ ** @param {number} ceiling - (optional) altitude of top of area, in hundreds of feet
+ ** @param {string} airspace_class - (optional) FAA airspace classification (A,B,C,D,E,G)
+ */
+var Area = Fiber.extend(function() {
+  return {
+    init: function(positions, /*optional*/ floor, ceiling, airspace_class) {
+      if(!positions) return;
+      this.poly     = [];
+      this.floor    = null;
+      this.ceiling  = null;
+      this.airspace_class = null;
+
+      if(floor != null) this.floor = floor;
+      if(ceiling != null) this.ceiling = ceiling;
+      if(airspace_class) this.airspace_class = airspace_class;
+
+      this.parse(positions);
+    },
+    parse: function(positions) {
+      for(var i=0; i<positions.length; i++) this.poly.push(positions[i]);
+      if(this.poly[0] == this.poly[this.poly.length-1])
+        this.poly.pop();  // shape shouldn't fully close; will draw with 'cc.closepath()'
+    }
+  };
+});

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -791,6 +791,8 @@ function canvas_draw_compass(cc) {
   }
 }
 
+/** Draw circular airspace border
+ */
 function canvas_draw_ctr(cc) {
   "use strict";
   
@@ -798,14 +800,10 @@ function canvas_draw_ctr(cc) {
   cc.translate(round(prop.canvas.size.width/2), round(prop.canvas.size.height/2));
   cc.translate(prop.canvas.panX, prop.canvas.panY);
   cc.fillStyle = "rgba(200, 255, 200, 0.02)";
+	cc.strokeStyle = "rgba(200, 255, 200, 0.25)";
   cc.beginPath();
   cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale, 0, Math.PI*2);
   cc.fill();
-  //Draw the outline circle
-	cc.beginPath();
-  cc.linewidth = 1;
-	cc.arc(0, 0, airport_get().ctr_radius*prop.ui.scale, 0, Math.PI*2);
-	cc.strokeStyle = "rgba(200, 255, 200, 0.25)";
 	cc.stroke();
 
   // Check if range ring characteristics are defined for this airport

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -854,13 +854,7 @@ function canvas_draw_fancy_rings(cc, fix_origin, fix1, fix2) {
 }
 
 function canvas_draw_range_rings(cc) {
-  // Check if range ring characteristics are defined for this airport
-  if(airport_get().hasOwnProperty("rr_radius_nm")) {
-    var rangeRingRadius = km(airport_get().rr_radius_nm); //convert input param from nm to km
-  }
-  else {
-    var rangeRingRadius = airport_get().ctr_radius / 4; //old method
-  }
+  var rangeRingRadius = km(airport_get().rr_radius_nm); //convert input param from nm to km
 
   //Fill up airport's ctr_radius with rings of the specified radius
   for(var i=1; i*rangeRingRadius < airport_get().ctr_radius; i++) {
@@ -882,6 +876,7 @@ function canvas_draw_poly(cc, poly) {
   cc.closePath();
   cc.stroke();
   cc.fill();
+  cc.clip();      // hide range rings outside of airspace boundary
 }
 
 function canvas_draw_terrain(cc) {

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -805,7 +805,12 @@ function point_in_poly(point, vs) {
     }
     
     return inside;
-};
+}
+
+function point_in_area(point, area) {
+  var poly = $.map(area.poly, function(v) {return [v.position];});
+  return point_in_poly(point, poly);
+}
 
 function endsWith(str, suffix) {
   return str.indexOf(suffix, str.length - suffix.length) !== -1;  


### PR DESCRIPTION
Related to #423 (makes progress toward that end).

Gives the option to change the airport's airspace border from being a circle to being definably polygonal, via a new `airspace` property in an airport's json file. This pull only includes the framework to do this (and shouldn't affect anything when not in use). For demonstration purposes, I traced in AutoCad the outer boundary of Minneapolis TRACON ("M98") from their real radar video map (right), and defined the airspace as being along those points, leading to the result in the sim (left).

![image](https://cloud.githubusercontent.com/assets/5103735/14575070/1d28e038-0325-11e6-9e68-bb22eb0543ec.png)

This is not a particularly attractive look, with the sharp edges, I understand-- but I'm thinking all of this would probably be turned on/off in settings, based on whether you want the full video map shown. If you don't, you get the classic circle edge, if you do, you get all the video map markings, and the airplanes "enter" the airspace when they cross that polygonal boundary.

Testing available here (use KMSP): [erikquinn.github.io/atc/b/polygonal-airspace/](http://erikquinn.github.io/atc/b/polygonal-airspace/)

^Note: That link includes changes to `kmsp.json` that _are not_ a part of this pull request. This PR only sets the framework to be able to add polygonal boundaries to airport json files easily in the future, and lays most of the ground work for #423.
