### PR TITLE
Flight Strip Bay Improvements

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -921,7 +921,7 @@ var Aircraft=Fiber.extend(function() {
         }
       }
 
-      $("#strips").append(this.html);
+      $("#strips").prepend(this.html);
 
       this.html.click(this, function(e) {
         input_select(e.data.getCallsign());
@@ -2022,7 +2022,7 @@ var Aircraft=Fiber.extend(function() {
     },
     showStrip: function() {
       this.html.detach();
-      $("#strips").append(this.html);
+      $("#strips").prepend(this.html);
       this.html.show(600);
     },
     updateTarget: function() {

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -921,7 +921,10 @@ var Aircraft=Fiber.extend(function() {
         }
       }
 
+      // var scrollPos = $("#strips")[0].scrollHeight - $("#strips").scrollTop();
+      var scrollPos = $("#strips").scrollTop();
       $("#strips").prepend(this.html);
+      $("#strips").scrollTop(scrollPos + 45);  // shift scroll down one strip's height
 
       this.html.click(this, function(e) {
         input_select(e.data.getCallsign());
@@ -2022,8 +2025,11 @@ var Aircraft=Fiber.extend(function() {
     },
     showStrip: function() {
       this.html.detach();
+      // var scrollPos = $("#strips")[0].scrollHeight - $("#strips").scrollTop();
+      var scrollPos = $("#strips").scrollTop();
       $("#strips").prepend(this.html);
-      this.html.show(600);
+      this.html.show();
+      $("#strips").scrollTop(scrollPos + 45);  // shift scroll down one strip's height
     },
     updateTarget: function() {
       var airport = airport_get();

--- a/assets/style/sidebar.css
+++ b/assets/style/sidebar.css
@@ -4,6 +4,7 @@
 #sidebar {
   background-color: rgba(0,0,0,0.7);
   color: #ddd;
+  border-bottom: 1px solid rgba(255,255,255,0.2);
 
   position: absolute;
   top: 0;
@@ -32,7 +33,8 @@
 
 #sidebar #strips {
   font-size: 80%;
-  padding: 10px;
+  padding-left: 8px;
+  padding-right: 8px;
   position: absolute;
   bottom: 0;
   width: 100%;

--- a/assets/style/sidebar.css
+++ b/assets/style/sidebar.css
@@ -10,7 +10,6 @@
   right: 0;
   width: 250px;
   height: calc(100% - 36px);
-  overflow-y: scroll;
 }
 
 .nice-scrollbar::-webkit-scrollbar {
@@ -34,6 +33,10 @@
 #sidebar #strips {
   font-size: 80%;
   padding: 10px;
-  height: 100%;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  max-height: 100%;
+  overflow-y: scroll;
 }
 

--- a/assets/style/strip.css
+++ b/assets/style/strip.css
@@ -3,6 +3,9 @@
   background-color: rgba(255, 255, 255, 0.0);
 
   border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 2px solid transparent; 
+  border-bottom: 2px solid transparent; 
 
   list-style-type: none;
   position: relative;
@@ -30,10 +33,14 @@
 
 .strip.arrival {
   border-color: rgba(224, 128, 128, 0.8);
+  border-top-color: rgba(224, 128, 128, 0.1);
+  border-bottom-color: rgba(224, 128, 128, 0.1);
 }
 
 .strip.departure {
   border-color: rgba(128, 255, 255, 0.8);
+  border-top-color: rgba(128, 255, 255, 0.05);
+  border-bottom-color: rgba(128, 255, 255, 0.05);
 }
 
 .strip .aircraft {

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     <div id="log">
     </div>
     <input id="command" placeholder="enter command" autofocus="true" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" />
-    <div id="sidebar" class='nice-scrollbar'>
-      <ul id="strips">
+    <div id="sidebar">
+      <ul id="strips" class='nice-scrollbar'>
       </ul>
     </div>
     <div id="score" title="Score">-</div>


### PR DESCRIPTION
Follow-up to #388, and fulfills the remaining intentions of that PR. The changes to the SIDs have been done elsewhere, and I now create this new PR which is the result of elaboration upon the discussions held in #388. If this is merged, then #388 has been fully effected, and thus would be closed. Also resolves #340 (the discussion that led to 388).

Changes:
- Flight Strips now stack "bottom-to-top" (stacked upwards like bricks of a wall)
- Strips given faint coloring that accentuates the red/blue coloring

![image](https://cloud.githubusercontent.com/assets/5103735/14782501/561ee41e-0aaf-11e6-9638-53d63c522983.png)

Test: [http://erikquinn.github.io/atc/b/stripStackage/](http://erikquinn.github.io/atc/b/stripStackage/)
