### PR TITLE
Airways, Legs, Rerouting, & So Much More

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -566,11 +566,12 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
       if(prev && !curr.speed) curr.speed = prev.speed;
     },
 
-    /** Insert a waypoint before the *curent* waypoint
+    /** Insert a waypoint at current position and immediately activate it
      */
-    prependWaypoint: function(data) {
+    insertWaypointHere: function(data) {
       var prev = this.currentWaypoint();
       this.currentLeg().waypoints.splice(this.current[1], 0, new zlsa.atc.Waypoint(data));
+      this.update_fp_route();
 
       // Verify altitude & speed not null
       var curr = this.currentWaypoint();
@@ -587,6 +588,9 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
       this.legs.splice(data.firstIndex, 0, new zlsa.atc.Leg(data, this));
       this.update_fp_route();
 
+      // Adjust 'current'
+      if(this.current[0] >= data.firstIndex) this.current[1] = 0;
+
       // Verify altitude & speed not null
       var curr = this.currentWaypoint();
       if(prev && !curr.altitude) curr.altitude = prev.altitude;
@@ -598,6 +602,7 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
     insertLegHere: function(data) {
       data.firstIndex = this.current[0];  // index of current leg
       this.insertLeg(data); // put new Leg at current position
+      this.current[1] = 0;  // start at first wp in this new leg
     },
 
     /** Insert a Leg at the end of the flightplan
@@ -611,6 +616,7 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
      */
     appendWaypoint: function(data) {
       this.currentLeg().waypoints.splice(this.current[1]+1, 0, new zlsa.atc.Waypoint(data));
+      this.update_fp_route();
     },
 
     /** Switch to the next waypoint

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -898,14 +898,13 @@ zlsa.atc.AircraftFlightManagementSystem = Fiber.extend(function() {
         else {  // no route continuity... just adding legs
           this.legs.splice.apply(this.legs, [this.current[0]+1, 0].concat(legs));  // insert the legs after the active Leg
           this.nextLeg();
-          this.update_fp_route();
         }
       }
       else {  // replace all legs with the legs we've built here in this function
         this.legs = legs;
         this.current = [0,0]; // look to beginning of route
-        this.update_fp_route();
       }
+      this.update_fp_route();
 
       // Maintain old speed and altitude
       if(this.currentWaypoint().altitude == null) this.setCurrent({altitude: curr.altitude});

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -597,7 +597,7 @@ var Runway=Fiber.extend(function(base) {
       }
       return false;
     },
-    isWaiting: function(aircraft) {
+    inQueue: function(aircraft) {
       return this.queue.indexOf(aircraft);
     },
     taxiDelay: function(aircraft) {
@@ -653,6 +653,7 @@ var Airport=Fiber.extend(function() {
       this.fixes    = {};
       this.real_fixes = {};
       this.sids     = {};
+      this.airways  = {};
       this.restricted_areas = [];
       this.metadata = {
         rwy: {}
@@ -731,9 +732,8 @@ var Airport=Fiber.extend(function() {
         }
       }
 
-      if(data.sids) {
-        this.sids = data.sids;
-      }
+      if(data.sids) this.sids = data.sids;
+      if(data.airways) this.airways = data.airways;
 
       if(data.restricted) {
         var r = data.restricted,

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -603,14 +603,6 @@ var Runway=Fiber.extend(function(base) {
     taxiDelay: function(aircraft) {
       return this.delay + Math.random() * 3;
     },
-    getOffset: function(position, length) {
-      position = [position[0], position[1]];
-      position = vsub(position, this.position);
-      var offset = [0, 0];
-      offset[0]  = ( cos(this.angle) * position[0]) - (sin(this.angle) * position[1]);
-      offset[1]  = (-sin(this.angle) * position[0]) - (cos(this.angle) * position[1]);
-      return offset;
-    },
     getGlideslopeAltitude: function(distance, /*optional*/ gs_gradient) {
       if(!gs_gradient) gs_gradient = this.ils.gs_gradient;
       distance = Math.max(0, distance);
@@ -933,10 +925,12 @@ var Airport=Fiber.extend(function() {
     },
     getFix: function(name) {
       if(!name) return null;
-      return this.fixes[name.toUpperCase()] || null;
+      if(Object.keys(airport_get().fixes).indexOf(name.toUpperCase()) == -1) return;
+      else return airport_get().fixes[name.toUpperCase()];
     },
     getSID: function(id, trxn, rwy) {
       if(!(id && trxn && rwy)) return null;
+      if(Object.keys(this.sids).indexOf(id) == -1) return;
       var fixes = [];
       var sid = this.sids[id];
 

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -393,7 +393,7 @@ function canvas_draw_aircraft(cc, aircraft) {
 
   if(aircraft.position_history.length > trailling_length) aircraft.position_history = aircraft.position_history.slice(aircraft.position_history.length - trailling_length, aircraft.position_history.length);
 
-  if( aircraft.isPrecisionGuided() && aircraft.altitude > 1000) {
+  if(aircraft.isPrecisionGuided()) {
     cc.save();
     canvas_draw_separation_indicator(cc, aircraft);
     cc.restore();

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -238,6 +238,27 @@ function angle_offset(a, b) {
   return offset;
 }
 
+/** Returns an offset array showing how far [fwd/bwd, left/right] 'aircraft' is of 'target'
+ ** @param {Aircraft} aircraft - the aircraft in question
+ ** @param {array} target - positional array of the targeted position [x,y]
+ ** @param {number} headingThruTarget - (optional) The heading the aircraft should
+ **                                     be established on when passing the target.
+ **                                     Default value is the aircraft's heading.
+ ** @returns {array} with two elements: retval[0] is the lateral offset, in km
+ **                                     retval[1] is the longitudinal offset, in km
+ **                                     retval[2] is the hypotenuse (straight-line distance), in km
+ */
+function getOffset(aircraft, target, /*optional*/ headingThruTarget) {
+  if(headingThruTarget == null) headingThruTarget = aircraft.heading;
+  var offset = [0, 0, 0];
+  var vector = vsub(target, aircraft.position); // vector from aircraft pointing to target
+  var bearingToTarget = vradial(vector);
+  offset[2] = vlen(vector);
+  offset[0] = offset[2] * sin(headingThruTarget - bearingToTarget);
+  offset[1] = offset[2] * cos(headingThruTarget - bearingToTarget);
+  return offset;
+}
+
 function heading_to_string(heading) {
   heading = round(mod(degrees(heading), 360)).toString();
   if(heading == "0") heading = "360";

--- a/assets/style/strip.css
+++ b/assets/style/strip.css
@@ -37,7 +37,7 @@
 }
 
 .strip .aircraft {
-  display: block;
+  display: table;
   font-style: italic;
 }
 


### PR DESCRIPTION
This is finally pretty much ready to go!

Includes a lot of back-end work to improve the way the fms handles route logic, so that routes can be manipulated in a way that is similar to real flight management systems, thus making it easier to achieve more complex routing operations, moving things around, and just overall enabling us to achieve a higher level of capability.

Basically, here's the jist of what happened to the fms:

> The current fms is set up to navigate between "waypoints", which are manually created objects, not associated with a particular class, that are made in the fms's `addWaypoint()` member function. You can add a whole bunch of these waypoints to the fms, and it will tell the aircraft to aim to each waypoint. As it passes each one, that waypoint is removed from the fms, and the others shift over, and the a/c goes to the next one. The process repeats until no waypoints remain, and then the aircraft will pass through the last waypoint and maintain its altitude/speed/heading when it passed its last waypoint.  
> In this proposed pull request, the fms has a modifiable flight plan route, which has corresponding "legs" that tell the fms where to steer the airplane. Each leg contains a series of waypoints. The purpose of doing it this way is to condense and clearly group together waypoints when they are part of an instrument procedure; for example, a SID or STAR will be maybe 5-10 fixes long, and may have specific altitude/speed limitations at each fix. By having these 5-10 waypoints contained within a `Leg`, you can clearly differentiate these fixes from the rest in the fms. If you wish to change to a different SID (perhaps because the one the aircraft had filed for is invalid from the runway you've taxiied them to), and all the waypoints were just loose in the fms, you wouldn't know which ones (or how many) to remove. Here, you just find the route that has `route.type == "sid"`, and replace it with a new leg, as simply as saying `fms.insertLegHere(new zlsa.atc.Leg({type: "sid", route: "KSFO.MOLEN7.ENI"}));`. Boom. The existing logic builds EVERYTHING else for you, as long as `MOLEN7` is a valid SID at `KSFO`, and `ENI` is a valid transition of that SID. If not, it'll throw an error and let you know the route is invalid. This is a better way to handle is because you can add/remove things easier, and better recognize when an aircraft is able to climb/descend via a SID/STAR, or whether they are on an airway, etc, which can be useful in many other applications.

_In Reference to Active Issues:_
- Resolves #350, via making a/c on ground invincible to all collisions (temporary solution)
- Resolves #461, by adding capability to parse, understand, use, and manipulate routes to accommodate airways
- Resolves #430, by moving the departure runway member variable from `fms` to `Aircraft`
- Enables us to easily add a fix for #439.
- Enables us to easily add a fix for #379.
- Enables us to easily add a fix for #407, and partially addresses the topics discussed by adding a `sr` command, for "say route"

Technical Changes:
- Added class `zlsa.atc.Waypoint`, based on old waypoint format
- Added class `zlsa.atc.Leg`, which is a functional part of the flightplan route, and contains a series of Waypoint objects
- Set up straightforward framework for stuff like vector/RNAV hybrid SIDs (#439), departing/crossing fixes on certain headings or at certain speeds (#379, #315)
- Fixed math error with `offset` calculations (used to be member fxn of `Runway`. now in `util.js` and set up to be more abstracted and versatile (this could help runway intercept weirdness and lays groundwork for intercepting radials or airways as if they were ILS localizers)

_Notable Features/Changes Included:_
- `route`, `rr` ("reroute"), and `sr` ("say route") commands
- Taxi time set to 3 seconds, and aircraft in the queue no longer are waiting around for days if you taxiied a bunch back to back. As long as each has had their 3 seconds, they will appear on the runway as soon as the departure ahead of them takes off. Note: All conflicts/crashes disabled while on ground (temporary fix).
- removed `proceed` command, as it is made moot by introduction of the more powerful and real-world accurate methods of rerouting aircraft via `route` or `rr` (reroute) commands

---

I have tested it pretty thoroughly, and continue finding small things that have broken, and I am sure there are more, but nothing that will hinder the gameplay, and nothing that can't be very easily fixed... It's just tough to track down them all, and I think I have just about everything running properly. There may be issues with something like rerouting, then assigning a fix, then clearing for an approach, then adding a hold (or something crazy like that that I didn't test), but I'm sure we will come across any such issues eventually if they exist, and we can deal with them then. This should be a really big step forward though, and enable some _really cool stuff_.

Testing on this is appreciated; let me know if you find anything broken!

Airways available in demo (not included in this PR) include:
`"V87": ["POPES", "SGD", "REBAS", "SFO", "OSI", "SANTY", "MOVER", "SNS"]`
`"V107": ["BOARS", "PYE", "MICRA", "COMMO", "OAK", "DECOT", "IMPLY", "MISON", "MABRY", "VINCO", "CATHE", "PXN"]`

Note: Aircraft can be made to follow airways via the `route` command, which adds a new Leg. Format your input with single-dots for airways, or double-dots for fixes. Alternatively, do `rr` instead of `route` to replace the aircraft's route entirely with a route of your own making (same format). An example of proper route format is `KSFO.OFFSH9.SXC.V458.IPL.J2.JCT..LLO..ACT..KACT`
### Testing: [erikquinn.github.io/atc/b/airways](http://erikquinn.github.io/atc/b/airways)
