### PR TITLE
Remove 'Work in Progress' tags for some airports

### DIFF
--- a/assets/airports/eddf.json
+++ b/assets/airports/eddf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Frankfurt Airport &#9983",
+  "name": "Frankfurt Airport",
   "level": "medium",
   "radio": {
     "twr": "Frankfurt Tower",

--- a/assets/airports/eddm.json
+++ b/assets/airports/eddm.json
@@ -1,5 +1,5 @@
 {
-  "name": "Franz Josef Strauß International Airport &#9983",
+  "name": "Franz Josef Strauß International Airport",
   "level": "beginner",
   "radio": {
     "twr": "München Tower",

--- a/assets/airports/engm.json
+++ b/assets/airports/engm.json
@@ -1,5 +1,5 @@
 {
-  "name": "Oslo Gardermoen International Airport &#9983",
+  "name": "Oslo Gardermoen International Airport",
   "level": "easy",
   "radio": {
     "twr": "Gardermoen Tower",


### PR DESCRIPTION
Since the WIP tags aren't necessary anymore at EDDF, EDDM and ENGM, this PR removes them.
