### PR TITLE
Fix issue #486

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -2214,7 +2214,7 @@ var Aircraft=Fiber.extend(function() {
     },
     cancelLanding: function() {
       if(this.fms.currentWaypoint().navmode == "rwy") {
-        var runway = airport_get().getRunway(this.rwy_dep);
+        var runway = airport_get().getRunway(this.rwy_arr);
         if(this.mode == "landing") {
           this.fms.setCurrent({
             altitude: Math.max(2000, round((this.altitude / 1000)) * 1000),


### PR DESCRIPTION
Resolves #486.

Fixes an erroneous result of a find-and-replace during fms restructuring. Aircraft will again be able to have their approach clearances canceled and they will fly normally afterward.
