### PR TITLE
Fixes #475 (Restricted Areas Not Drawn)

### DIFF
--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -819,6 +819,7 @@ function canvas_draw_airspace_border(cc) {
   // draw airspace
   for(var i=0; i<airport_get().airspace.length; i++) {
     canvas_draw_poly(cc, $.map(airport_get().perimeter.poly, function(v){return [v.position];}));
+    cc.clip();
   }
 }
 

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -878,7 +878,6 @@ function canvas_draw_poly(cc, poly) {
   cc.closePath();
   cc.stroke();
   cc.fill();
-  cc.clip();      // hide range rings outside of airspace boundary
 }
 
 function canvas_draw_terrain(cc) {


### PR DESCRIPTION
the cc.clip() was preventing the canvas from drawing all restricted areas but the first. Deleting this line doesn't seem to affect the range rings. This PR fixes #475 
