### PR TITLE
Remove arrow functions and spread operator for IE compatibility

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -693,7 +693,7 @@ var Airport=Fiber.extend(function() {
         var pos = new Position(this.perimeter.poly[0].position, this.position, this.magnetic_north);
         var len = nm(vlen(vsub(pos.position, this.position.position)));
         var apt = this;
-        this.ctr_radius = Math.max(...$.map(this.perimeter.poly, function(v) {return vlen(vsub(v.position,new Position(apt.rr_center, apt.position, apt.magnetic_north).position));}));
+        this.ctr_radius = Math.max.apply(Math, $.map(this.perimeter.poly, function(v) {return vlen(vsub(v.position,new Position(apt.rr_center, apt.position, apt.magnetic_north).position));}));
       }
       
       if(data.runways) {
@@ -1135,7 +1135,7 @@ var Airport=Fiber.extend(function() {
       }
 
       // Get (unique) list of fixes used that are not in 'this.fixes'
-      var missing = fixes.filter(f => !this.fixes.hasOwnProperty(f)).sort();
+      var missing = fixes.filter(function(f){return !this.fixes.hasOwnProperty(f);}).sort();
       for(var i=0; i<missing.length-1; i++)
         if(missing[i] == missing[i+1]) missing.splice(i,1); // remove duplicates
       if(missing.length > 0) {  // there are some... yell at the airport designer!!! :)


### PR DESCRIPTION
Resolves #477, _at least_ the Internet Explorer portion. Was due to the use of one arrow function and one use of the spread operator, which is not yet cool with IE.

I _assume_ Safari's problem is the same, but I am unable to verify it is 100% fixed. What I can say is that the issue described here no longer happens. In Safari, the game now loads completely, but doesn't display the airport (blank green) for the version I have. This may not be a fair test though, because I am on windows, and only can get Safari 5.1.7 (about four years old, v9.1 is current). Since it loads, I imagine the problem is the same as it was with IE, and _should_ theoretically be working now.
