### PR TITLE
Fix error from climbViaSID

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1972,7 +1972,7 @@ var Aircraft=Fiber.extend(function() {
       else return [true, "unable to clear as filed"];
     },
     runClimbViaSID: function() {
-      if(!this.fms.currentLeg().type == "sid") var fail = true;
+      if(!(this.fms.currentLeg().type == "sid")) var fail = true;
       else if(this.fms.climbViaSID())
         return ['ok', {log: "climb via the " + this.fms.currentLeg().route.split('.')[1] + " departure",
           say: "climb via the " + airport_get().sids[this.fms.currentLeg().route.split('.')[1]].name + " departure"}];


### PR DESCRIPTION
Resolves #522.

Aircraft will now respond with this, as I originially intended (had I known how to use parentheses!) if they don't have one assigned:
![image](https://cloud.githubusercontent.com/assets/5103735/15625341/d699f61a-2468-11e6-8885-fb2464b35024.png)

And if they do, it will proceed normally.
