### PR TITLE
Repair fix validation logic

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -1135,7 +1135,8 @@ var Airport=Fiber.extend(function() {
       }
 
       // Get (unique) list of fixes used that are not in 'this.fixes'
-      var missing = fixes.filter(function(f){return !this.fixes.hasOwnProperty(f);}).sort();
+      var apt = this;
+      var missing = fixes.filter(function(f){return !apt.fixes.hasOwnProperty(f);}).sort();
       for(var i=0; i<missing.length-1; i++)
         if(missing[i] == missing[i+1]) missing.splice(i,1); // remove duplicates
       if(missing.length > 0) {  // there are some... yell at the airport designer!!! :)


### PR DESCRIPTION
- 'this' was referencing the window instead of the airport object while running .checkFixes() via .parse() of airport during initialization
- now the fix validation logic works the way it is supposed to

Found via discussions in #531.
