### PR TITLE
Fixes #542

### DIFF
--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -1232,6 +1232,7 @@ function airport_set(icao) {
     .text(prop.airport.current.icao.toUpperCase())
     .attr("title", airport.name);
 
+  prop.canvas.draw_labels = true;
   $('.toggle-labels').toggle(
     !$.isEmptyObject(prop.airport.current.maps));
 


### PR DESCRIPTION
This PR fixes the issue described in #542 . I didn't explain it very clearly, so I'm gonna try to explain it here. The airports that have video maps, look very hideous because of all the fixes and labels being drawn: 
![part 1](https://cloud.githubusercontent.com/assets/13125311/15728883/4edd940a-2857-11e6-8bbc-3ed932b373fc.PNG)
Thankfully, we can toggle the drawing of fixes and labels, which looks MUCH better:
![part 2](https://cloud.githubusercontent.com/assets/13125311/15728897/6bddf00e-2857-11e6-8a90-bad6eed0ba36.PNG)
The problem comes when the toggle fixes and labels button is disabled and we then switch to an airport which doesn't contain a video map. The issue is that fixes and labels are not drawn and there's no button to change that:
![part 3](https://cloud.githubusercontent.com/assets/13125311/15728923/a6630bf6-2857-11e6-8a28-70f6640963cd.PNG)
This PR simply adds a line, which draws fixes and labels by default every time you load an airport
