### PR TITLE
Asynchronously load aircraft, airlines and airports

### DIFF
--- a/assets/airports/ebbr.json
+++ b/assets/airports/ebbr.json
@@ -1,7 +1,5 @@
 {
   "reference": "https://www.belgocontrol.be/opersite/eaip/eAIP_Main/html/eAIP/EB-AD-2.EBBR-en-GB.html",
-  "name": "Brussels-National &#9983",
-  "level": "easy",
   "radio": {
     "twr": "Brussels Tower",
     "app": "Brussels Approach",

--- a/assets/airports/eddf.json
+++ b/assets/airports/eddf.json
@@ -1,6 +1,4 @@
 {
-  "name": "Frankfurt Airport",
-  "level": "medium",
   "radio": {
     "twr": "Frankfurt Tower",
     "app": "Langen Radar",

--- a/assets/airports/eddh.json
+++ b/assets/airports/eddh.json
@@ -1,6 +1,4 @@
  {
-  "name": "Hamburg Airport",
-  "level": "easy",
   "radio": {
     "twr": "Hamburg Tower",
     "app": "Hamburg Director",

--- a/assets/airports/eddm.json
+++ b/assets/airports/eddm.json
@@ -1,6 +1,4 @@
 {
-  "name": "Franz Josef Strauß International Airport",
-  "level": "beginner",
   "radio": {
     "twr": "München Tower",
     "app": "München Radar",

--- a/assets/airports/eddt.json
+++ b/assets/airports/eddt.json
@@ -1,6 +1,4 @@
  {
-  "name": "Berlin Tegel Airport",
-  "level": "medium",
   "radio": {
     "twr": "Tegel Tower",
     "app": "Berlin Director",

--- a/assets/airports/egcc.json
+++ b/assets/airports/egcc.json
@@ -1,6 +1,4 @@
  {
-  "name": "Manchester Airport",
-  "level": "hard",
   "radio": {
     "twr": "Manchester Tower",
     "app": "Manchester Director",

--- a/assets/airports/egkk.json
+++ b/assets/airports/egkk.json
@@ -1,6 +1,4 @@
 {
-  "name": "London Gatwick Airport",
-  "level": "easy",
   "radio": {
     "twr": "Gatwick Tower",
     "app": "London Control",

--- a/assets/airports/eglc.json
+++ b/assets/airports/eglc.json
@@ -1,6 +1,4 @@
 {
-  "name": "London City Airport",
-  "level": "medium",
   "radio": {
     "twr": "City Tower",
     "app": "Thames Radar",

--- a/assets/airports/egll.json
+++ b/assets/airports/egll.json
@@ -1,6 +1,4 @@
 {
-  "name": "London Heathrow Airport",
-  "level": "hard",
   "radio": {
     "twr": "Heathrow Tower",
     "app": "Heathrow Director",

--- a/assets/airports/eham.json
+++ b/assets/airports/eham.json
@@ -1,6 +1,4 @@
 {
-  "name": "Amsterdam Airport Schiphol",
-  "level": "medium",
   "radio": {
     "twr": "Amsterdam Tower",
     "app": "Amsterdam Approach",

--- a/assets/airports/eidw.json
+++ b/assets/airports/eidw.json
@@ -1,6 +1,4 @@
 {
-  "name": "Dublin Airport",
-  "level": "easy",
   "radio": {
     "twr": "Dublin Tower",
     "app": "Dublin Approach",

--- a/assets/airports/einn.json
+++ b/assets/airports/einn.json
@@ -1,6 +1,4 @@
 {
-  "name": "Shannon Airport",
-  "level": "easy",
   "radio": {
     "twr": "Shannon Tower",
     "app": "Shannon Approach",

--- a/assets/airports/ekch.json
+++ b/assets/airports/ekch.json
@@ -1,6 +1,4 @@
 {
-  "name": "Copenhagen Kastrup Airport",
-  "level": "medium",
   "radio": {
     "twr": "Kastrup Tower",
     "app": "Copenhagen Approach",

--- a/assets/airports/engm.json
+++ b/assets/airports/engm.json
@@ -1,6 +1,4 @@
 {
-  "name": "Oslo Gardermoen International Airport",
-  "level": "easy",
   "radio": {
     "twr": "Gardermoen Tower",
     "app": "Oslo Approach",

--- a/assets/airports/espa.json
+++ b/assets/airports/espa.json
@@ -1,6 +1,4 @@
 {
-  "name": "Luleå Airport",
-  "level": "easy",
   "radio": {
     "twr": "Kallax Tower",
     "app": "Kallax Control",

--- a/assets/airports/kbos.json
+++ b/assets/airports/kbos.json
@@ -1,6 +1,4 @@
 {
-  "name": "Boston Logan International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Boston Tower",
     "app": "Boston Approach",

--- a/assets/airports/kdca.json
+++ b/assets/airports/kdca.json
@@ -1,6 +1,4 @@
 {
-  "name": "Reagan National Airport",
-  "level": "medium",
   "radio": {
     "twr": "Washington Tower",
     "app": "Potomac Approach",

--- a/assets/airports/kjfk.json
+++ b/assets/airports/kjfk.json
@@ -1,6 +1,4 @@
 {
-  "name": "John F Kennedy International Airport &#9983",
-  "level": "hard",
   "radio": {
     "twr": "Kennedy Tower",
     "app": "New York Approach",

--- a/assets/airports/klax.json
+++ b/assets/airports/klax.json
@@ -1,6 +1,4 @@
 {
-  "name": "Los Angeles International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Los Angeles Tower",
     "app": "SoCal Approach",

--- a/assets/airports/klax90.json
+++ b/assets/airports/klax90.json
@@ -1,6 +1,4 @@
 {
-  "name": "Los Angeles International Airport 1990",
-  "level": "medium",
   "radio": {
     "twr": "Los Angeles Tower",
     "app": "SoCal Approach",

--- a/assets/airports/kmia.json
+++ b/assets/airports/kmia.json
@@ -1,6 +1,4 @@
 {
-  "name": "Miami International Airport &#9983",
-  "level": "medium",
   "radio": {
     "twr": "Miami Tower",
     "app": "Miami Approach",

--- a/assets/airports/kmsp.json
+++ b/assets/airports/kmsp.json
@@ -1,6 +1,4 @@
 {
-  "name": "Minneapolis/St. Paul International Airport &#9983",
-  "level": "hard",
   "radio": {
     "twr": "Minneapolis Tower",
     "app": "Minneapolis Approach",

--- a/assets/airports/ksan.json
+++ b/assets/airports/ksan.json
@@ -1,6 +1,4 @@
 {
-  "name": "San Diego International Airport",
-  "level": "easy",
   "radio": {
     "twr": "Lindbergh Tower",
     "app": "SoCal Approach",

--- a/assets/airports/ksea.json
+++ b/assets/airports/ksea.json
@@ -1,6 +1,4 @@
 {
-  "name": "Seattle-Tacoma International Airport &#9983",
-  "level": "medium",
   "radio": {
     "twr": "Seatle Tower",
     "app": "Seattle Approach",

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -1,6 +1,4 @@
 {
-  "name": "San Francisco International Airport &#9983",
-  "level": "medium",
   "radio": {
     "twr": "San Francisco Tower",
     "app": "NorCal Approach",

--- a/assets/airports/loww.json
+++ b/assets/airports/loww.json
@@ -1,6 +1,4 @@
 {
-  "name": "Vienna International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Vienna Tower",
     "app": "Vienna Director",

--- a/assets/airports/ltba.json
+++ b/assets/airports/ltba.json
@@ -1,6 +1,4 @@
 {
-  "name": "Atatürk International Airport &#9983",
-  "level": "hard",
   "radio": {
     "twr": "Istanbul Tower",
     "app": "Istanbul Approach",

--- a/assets/airports/omaa.json
+++ b/assets/airports/omaa.json
@@ -1,6 +1,4 @@
 {
-  "name": "Abu Dhabi International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Abu Dhabi Tower",
     "app": "Abu Dhabi Arrivals",

--- a/assets/airports/omdb.json
+++ b/assets/airports/omdb.json
@@ -1,6 +1,4 @@
 {
-  "name": "Dubai International Airport",
-  "level": "hard",
   "radio": {
     "twr": "Dubai Tower",
     "app": "Dubai Arrivals",

--- a/assets/airports/othh.json
+++ b/assets/airports/othh.json
@@ -1,7 +1,5 @@
 {
   "_comment": "Thanks to Qatar for providing much of this information in the Qatar AIP: https://www.aim.gov.qa/eaip/2016-03-31-AIRAC/html/index-en-GB.html - indianbhaji June 9th '16",
-  "name": "Doha Hamad International Airport",
-  "level": "hard",
   "radio": {
     "twr": "Hamad Tower",
     "app": "Doha Approach",

--- a/assets/airports/saez.json
+++ b/assets/airports/saez.json
@@ -1,6 +1,4 @@
 {
-  "name": "Aeropuerto Internacional Ministro Pistarini",
-  "level": "medium",
   "radio": {
     "twr": "Ezeiza Tower",
     "app": "Baires Center",

--- a/assets/airports/sbgl.json
+++ b/assets/airports/sbgl.json
@@ -1,6 +1,4 @@
 {
-  "name": "Aeroporto Internacional Tom Jobim",
-  "level": "beginner",
   "radio": {
     "twr": "Galeão Tower",
     "app": "Galeão Approach",

--- a/assets/airports/sbgr.json
+++ b/assets/airports/sbgr.json
@@ -1,6 +1,4 @@
 {
-  "name": "Aeroporto Internacional de São Paulo/Guarulhos",
-  "level": "beginner",
   "radio": {
     "twr": "Guarulhos Tower",
     "app": "Guarulhos Approach",

--- a/assets/airports/tncm.json
+++ b/assets/airports/tncm.json
@@ -1,6 +1,4 @@
 {
-  "name": "Princess Juliana International Airport",
-  "level": "easy",
   "radio": {
     "twr": "Juliana Tower",
     "app": "Juliana Approach",

--- a/assets/airports/uudd.json
+++ b/assets/airports/uudd.json
@@ -1,6 +1,4 @@
 {
-  "name": "Moscow Domodedovo Airport",
-  "level": "easy",
   "radio": {
     "twr": "Domodedovo Tower",
     "app": "Domodedovo Approach",

--- a/assets/airports/vecc.json
+++ b/assets/airports/vecc.json
@@ -1,6 +1,4 @@
 {
-  "name": "Kolkata Netaji Subhas Chandra Bose Int'l",
-  "level": "medium",
   "radio": {
     "twr": "Kolkata Tower",
     "app": "Kolkata Approach",

--- a/assets/airports/vhhh.json
+++ b/assets/airports/vhhh.json
@@ -1,6 +1,4 @@
 {
-  "name": "Hong Kong Chep Lap Kok International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Hong Kong Tower",
     "app": "Hong Kong Approach",

--- a/assets/airports/vidp.json
+++ b/assets/airports/vidp.json
@@ -1,6 +1,4 @@
 {
-  "name": "Indira Gandhi International Airport",
-  "level": "hard",
   "radio": {
     "twr": "Delhi Tower",
     "app": "Delhi Approach",

--- a/assets/airports/wiii.json
+++ b/assets/airports/wiii.json
@@ -1,6 +1,4 @@
 {
-  "name": "Soekarno-Hatta International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Soekarno-Hatta Tower",
     "app": "Jakarta Approach",

--- a/assets/airports/wimm.json
+++ b/assets/airports/wimm.json
@@ -1,6 +1,4 @@
 {
-  "name": "Kuala Namu International Airport",
-  "level": "easy",
   "radio": {
     "twr": "Medan Tower",
     "app": "Medan Approach",

--- a/assets/airports/wmkp.json
+++ b/assets/airports/wmkp.json
@@ -1,6 +1,4 @@
 {
-  "name": "Pulau Pinang International Airport",
-  "level": "medium",
   "radio": {
     "twr": "Penang Tower",
     "app": "Butterworth Approach",

--- a/assets/airports/wsss.json
+++ b/assets/airports/wsss.json
@@ -1,6 +1,4 @@
 {
-  "name": "Singapore Changi International Airport",
-  "level": "hard",
   "radio": {
     "twr": "Singapore Tower",
     "app": "Singapore Approach",

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -3221,22 +3221,8 @@ function aircraft_callsign_new(airline) {
 }
 
 function aircraft_new(options) {
-  if(!options.callsign) options.callsign = aircraft_callsign_new(options.airline);
-
-  if(!options.icao) {
-    options.icao = airline_get(options.airline).chooseAircraft(options.fleet);
-  }
-  var icao = options.icao.toLowerCase();
-
-  if (!(icao in prop.aircraft.models)) {
-    var model = new Model({
-      icao: icao,
-      url: "assets/aircraft/"+icao+".json",
-    });
-    options.model = model;
-    prop.aircraft.models[icao] = model;
-  }
-  return prop.aircraft.models[icao].generateAircraft(options);
+  var airline = airline_get(options.airline);
+  return airline.generateAircraft(options);
 }
 
 function aircraft_get_nearest(position) {
@@ -3380,4 +3366,15 @@ function aircraft_get_eid_by_callsign(callsign) {
     if(prop.aircraft.list[i].callsign == callsign.toLowerCase())
       return prop.aircraft.list[i].eid;
   return null;
+}
+
+function aircraft_model_get(icao) {
+  if (!(icao in prop.aircraft.models)) {
+    var model = new Model({
+      icao: icao,
+      url: "assets/aircraft/"+icao+".json",
+    });
+    prop.aircraft.models[icao] = model;
+  }
+  return prop.aircraft.models[icao];
 }

--- a/assets/scripts/airline.js
+++ b/assets/scripts/airline.js
@@ -13,7 +13,7 @@ zlsa.atc.Airline = Fiber.extend(function() {
      */
     init: function (icao, options) {
       /** ICAO airline designation */
-      this.icao = "YYY";
+      this.icao = icao;
 
       /** Agency name */
       this.name = "Default airline";
@@ -34,25 +34,29 @@ zlsa.atc.Airline = Fiber.extend(function() {
         default: [],
       };
 
-      this.parse(icao, options);
+      this.loading = true;
+      this.loaded = false;
+      this._pendingAircraft = [];
+      this.parse(options);
+      if (options.url) this.load(options.url);
     },
 
     /**
      * Initialize object from data
      */
-    parse: function (icao, data) {
-      if (data.icao)
-        this.icao = data.icao;
-      else
-        this.icao = icao;
+    parse: function (data) {
+      if (data.icao) this.icao = data.icao;
 
-      this.name = data.name;
-      this.callsign = data.callsign.name;
-      this.flightNumberGeneration.length = data.callsign.length;
-      this.flightNumberGeneration.alpha = (data.callsign.alpha === true);
+      if (data.name) this.name = data.name;
+      if (data.callsign) {
+        this.callsign = data.callsign.name;
+        if (data.callsign.length)
+          this.flightNumberGeneration.length = data.callsign.length;
+        this.flightNumberGeneration.alpha = (data.callsign.alpha === true);
+      }
       if (data.fleets)
         this.fleets = data.fleets;
-      else
+      else if (data.aircraft)
         this.fleets.default = data.aircraft;
 
       for (var f in this.fleets) {
@@ -60,6 +64,27 @@ zlsa.atc.Airline = Fiber.extend(function() {
           this.fleets[f][j][0] = this.fleets[f][j][0].toLowerCase();
         }
       }
+    },
+
+    /**
+     * Load the data for this airline
+     */
+    load: function(url) {
+      if (this.loaded)
+        return;
+      $.getJSON(url)
+        .done(function (data) {
+          this.parse(data);
+          this.loading = false;
+          this.loaded = true;
+          this._generatePendingAircraft();
+        }.bind(this))
+        .fail(function (jqXHR, textStatus, errorThrown) {
+          this.loading = false;
+          this._pendingAircraft = [];
+          console.error("Unable to load airline/" + this.icao
+                        + ": " + textStatus);
+        }.bind(this));
     },
 
     /**
@@ -79,6 +104,24 @@ zlsa.atc.Airline = Fiber.extend(function() {
                     + " for airline " + this.icao);
         throw e;
       }
+    },
+
+    /**
+     * Create an aircraft
+     */
+    generateAircraft: function(options) {
+      if (!this.loaded) {
+        if (this.loading) {
+          this._pendingAircraft.push(options);
+          return true;
+        }
+        else {
+          console.warn("Unable to spawn aircraft for airline/" + this.icao
+                       + " as loading failed");
+          return false;
+        }
+      }
+      return this._generateAircraft(options);
     },
 
     /**
@@ -120,139 +163,31 @@ zlsa.atc.Airline = Fiber.extend(function() {
         }
       }
     },
+
+    _generateAircraft: function(options) {
+      if(!options.callsign) options.callsign = aircraft_callsign_new(options.airline);
+
+      if(!options.icao) {
+        options.icao = this.chooseAircraft(options.fleet);
+      }
+      var model = aircraft_model_get(options.icao.toLowerCase());
+      return model.generateAircraft(options);
+      var icao = options.icao.toLowerCase();
+    },
+
+    /**
+     * Generate aircraft which were queued while the model loaded
+     */
+    _generatePendingAircraft: function() {
+      $.each(this._pendingAircraft, function (idx, options) {
+        this._generateAircraft(options);
+      }.bind(this));
+      this._pendingAircraft = null;
+    },
   };
 });
 
 function airline_init() {
-  airline_load("AAL");
-  airline_load("ACA");
-  airline_load("AEA");
-  airline_load("AFL");
-  airline_load("AFR");
-  airline_load("AIC");
-  airline_load("AIRTAXI");
-  airline_load("AMX");
-  airline_load("ARG");
-  airline_load("ASA");
-  airline_load("ASQ");
-  airline_load("AUA");
-  airline_load("AVA");
-  airline_load("AWE");
-  airline_load("AWI");
-  airline_load("AWQ");
-  airline_load("AXB");
-  airline_load("AXM");
-  airline_load("AZA");
-  airline_load("AZU");
-  airline_load("BAW");
-  airline_load("BCY");
-  airline_load("BEE");
-  airline_load("BEL");
-  airline_load("BER");
-  airline_load("BTK");
-  airline_load("BWA");
-  airline_load("CCA");
-  airline_load("CES");
-  airline_load("CESSNA");
-  airline_load("CFG");
-  airline_load("CFS");
-  airline_load("CPA");
-  airline_load("CPZ");
-  airline_load("CSN");
-  airline_load("CTV");
-  airline_load("CWC");
-  airline_load("DAL");
-  airline_load("DLH");
-  airline_load("DTR");
-  airline_load("EIN");
-  airline_load("EMBRAER");
-  airline_load("ENY");
-  airline_load("ETD");
-  airline_load("EVA");
-  airline_load("EXS");
-  airline_load("EZY");
-  airline_load("FAB");
-  airline_load("FASTGA");
-  airline_load("FDB");
-  airline_load("FDX");
-  airline_load("FFM");
-  airline_load("FFT");
-  airline_load("FLG");
-  airline_load("FWI");
-  airline_load("GIA");
-  airline_load("GJS");
-  airline_load("GLO");
-  airline_load("GOW");
-  airline_load("GWI");
-  airline_load("HAL");
-  airline_load("HDA");
-  airline_load("IAD");
-  airline_load("IBE");
-  airline_load("IGO");
-  airline_load("INC");
-  airline_load("JAI");
-  airline_load("JAL");
-  airline_load("JBU");
-  airline_load("JIA");
-  airline_load("JSA");
-  airline_load("JTG");
-  airline_load("KAL");
-  airline_load("KAP");
-  airline_load("KLC");
-  airline_load("KLM");
-  airline_load("LAN");
-  airline_load("LIGHTGA");
-  airline_load("LLR");
-  airline_load("LNI");
-  airline_load("MAS");
-  airline_load("MON");
-  airline_load("MOV");
-  airline_load("NAX");
-  airline_load("NKS");
-  airline_load("ONE");
-  airline_load("PAA");
-  airline_load("PDT");
-  airline_load("QFA");
-  airline_load("QTR");
-  airline_load("QXE");
-  airline_load("RFF");
-  airline_load("RLU");
-  airline_load("RPA");
-  airline_load("RYR");
-  airline_load("SAS");
-  airline_load("SBI");
-  airline_load("SCO");
-  airline_load("SCX");
-  airline_load("SEJ");
-  airline_load("SIA");
-  airline_load("SJY");
-  airline_load("SKW");
-  airline_load("SLK");
-  airline_load("SQC");
-  airline_load("SVR");
-  airline_load("SWA");
-  airline_load("SWR");
-  airline_load("SXD");
-  airline_load("TAM");
-  airline_load("TCF");
-  airline_load("TCX");
-  airline_load("TGW");
-  airline_load("THY");
-  airline_load("TOM");
-  airline_load("TSO");
-  airline_load("TUI");
-  airline_load("TWA");
-  airline_load("TYA");
-  airline_load("UAE");
-  airline_load("UAL");
-  airline_load("UPS");
-  airline_load("USAF");
-  airline_load("VIR");
-  airline_load("VKG");
-  airline_load("VRD");
-  airline_load("VTI");
-  airline_load("WIA");
-  airline_load("XAX");
 }
 
 function airline_load(icao) {
@@ -271,11 +206,10 @@ function airline_load(icao) {
 
 function airline_get(icao) {
   icao = icao.toLowerCase();
-  return prop.airline.airlines[icao];
-}
-
-function airline_ready() {
-  for(var i in prop.airline.airlines) {
-    prop.airline.airlines[i].validateFleets();
+  if (!(icao in prop.airline.airlines)) {
+    var airline = new zlsa.atc.Airline(icao,
+                                       {url: "assets/airlines/"+icao+".json",});
+    prop.airline.airlines[icao] = airline;
   }
+  return prop.airline.airlines[icao];
 }

--- a/assets/scripts/airline.js
+++ b/assets/scripts/airline.js
@@ -112,12 +112,6 @@ zlsa.atc.Airline = Fiber.extend(function() {
     validateFleets: function () {
       for (var f in this.fleets) {
         for (var j=0;j<this.fleets[f].length;j++) {
-          if (!(this.fleets[f][j][0] in prop.aircraft.models)) {
-            console.warn("Airline " + this.icao.toUpperCase()
-                         + " uses nonexistent aircraft " + this.fleets[f][j][0]
-                         + ", expect errors");
-          }
-
           if (typeof this.fleets[f][j][1] != "number") {
             console.warn("Airline " + this.icao.toUpperCase()
                          + " uses non numeric weight for aircraft " +

--- a/assets/scripts/modules.js
+++ b/assets/scripts/modules.js
@@ -266,12 +266,11 @@ function done() {
   $(window).resize(resize);
   resize();
   call_module("*","done");
-  async_wait(function() {
-    prop.loaded=true;
-    call_module("*","ready");
-    if(UPDATE)
-      requestAnimationFrame(update);
-  });
+
+  prop.loaded=true;
+  call_module("*","ready");
+  if(UPDATE)
+    requestAnimationFrame(update);
 }
 
 function resize() {
@@ -283,17 +282,17 @@ function update() {
     call_module("*","complete");
     prop.complete=true;
   }
-//  call_module("*","update_pre");
-//  call_module("*","update");
-//  call_module("*","update_post");
+
+  if(UPDATE)
+    requestAnimationFrame(update);
+  else
+    return;
 
   game_update_pre();
   aircraft_update();
 
   canvas_update_post();
 
-  if(UPDATE)
-    requestAnimationFrame(update);
   prop.time.frames+=1;
   prop.time.frame.count+=1;
   var elapsed=time()-prop.time.frame.start;
@@ -304,6 +303,15 @@ function update() {
   }
   prop.time.frame.delta=Math.min(time()-prop.time.frame.last,1/20);
   prop.time.frame.last=time();
+}
+
+/**
+ * Change whether updates should run
+ */
+function update_run(arg) {
+  if ((!UPDATE) && arg)
+    requestAnimationFrame(update);
+  UPDATE=arg;
 }
 
 function delta() {

--- a/documentation/airport-format.md
+++ b/documentation/airport-format.md
@@ -11,8 +11,6 @@ airport code, such as `ksfo` or `kmsp`.
 
 ```
 {
-  "name": "Human-readable name of the airport",
-  "level": "beginner, easy, medium, hard or expert",
   "radio": {
     "twr": "controller callsign for tower",
     "app": "controller callsign for approach control",


### PR DESCRIPTION
This moves the airline/aircraft load to asynchronous during game play.  A demo is available at http://tedrek.github.io/atc

The tradeoff is that first load of aircraft will be a second or two later than normal, and the player needs to remain connected.  I don't think either of these are a big issue.

This should address #402.

A similiar technique could be applied to airports and geojson files if the airport list information is pre-populated.
