### PR TITLE
Simultaneous Dependent ILS Approaches (Fix)

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -170,6 +170,7 @@ zlsa.atc.Conflict = Fiber.extend(function() {
 
       var conflict = false;
       var violation = false;
+      var disableNotices = false;
       var a1 = this.aircraft[0], a2 = this.aircraft[1];
 
 
@@ -179,11 +180,12 @@ zlsa.atc.Conflict = Fiber.extend(function() {
 
       // Established on precision guided approaches
       if ( (a1.isPrecisionGuided() && a2.isPrecisionGuided()) &&
-           (a1.rwy_dep != a2.rwy_dep)) { // both are following different instrument approaches
-        var runwayRelationship = airport_get().metadata.rwy[a1.rwy_dep][a2.rwy_dep];
+           (a1.rwy_arr != a2.rwy_arr)) { // both are following different instrument approaches
+        var runwayRelationship = airport_get().metadata.rwy[a1.rwy_arr][a2.rwy_arr];
         if (runwayRelationship.parallel) {
           // Determine applicable lateral separation minima for conducting
           // parallel simultaneous dependent approaches on these runways:
+          disableNotices = true;  // hide notices for aircraft on adjacent final approach courses
           var feetBetween = km_ft(runwayRelationship.lateral_dist);
           if(feetBetween < 2500)  // Runways separated by <2500'
             var applicableLatSepMin = 5.556;  // 3.0nm
@@ -208,8 +210,8 @@ zlsa.atc.Conflict = Fiber.extend(function() {
 
 
       // Considering all of the above cases,...
-      conflict  = (this.distance < applicableLatSepMin + 1.852);  // +1.0nm
       violation = (this.distance < applicableLatSepMin);
+      conflict  = (this.distance < applicableLatSepMin + 1.852 && !disableNotices) || violation;  // +1.0nm
 
 
       // "Passing & Diverging" Rules (the "exception" to all of the above rules)

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -806,11 +806,12 @@ var Airport=Fiber.extend(function() {
               //setup secondary runway subobject
               var r1  = this.runways[rwy1][rwy1end];
               var r2  = this.runways[rwy2][rwy2end];
+              var offset = getOffset(r1, r2.position, r1.angle);
               this.metadata.rwy[r1.name][r2.name] = {};
 
               // generate this runway pair's relationship data
-              this.metadata.rwy[r1.name][r2.name].lateral_dist =
-                distance2d(r1.position, r2.position);
+              this.metadata.rwy[r1.name][r2.name].lateral_dist = abs(offset[1]);
+              this.metadata.rwy[r1.name][r2.name].straight_dist = abs(offset[2]);
               this.metadata.rwy[r1.name][r2.name].converging =
                 raysIntersect(r1.position, r1.angle, r2.position, r2.angle);
               this.metadata.rwy[r1.name][r2.name].parallel =


### PR DESCRIPTION
Make rwy lateral_dist the dist between the centerlines instead of the straight-line distance. This was causing problems at KMIA, because their parallel runways are separated by 6,300' threshold to threshold, but ~4,500' centerline to centerline. This was causing a 3nm sep minimum to be applied when the appropriate minima was based on the 4,500' figure (2.0nm on adjacent approach courses).

Fixed with this, and also removes notices for conflicts with aircraft on an adjacent final approach course, as no CA is displayed in real life in this situation until separation is lost (due to the stable nature of the flight paths, there's no need for the system to draw the controller's attention to it).

Blocks #584.
