### PR TITLE
Spawn backfill

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -2193,7 +2193,7 @@ var Aircraft=Fiber.extend(function() {
       }
     },
     parse: function(data) {
-      var keys = 'position model airline callsign category heading altitude'.split(' ');
+      var keys = 'position model airline callsign category heading altitude speed'.split(' ');
       for (var i in keys) {
         if (data[keys[i]]) this[keys[i]] = data[keys[i]];
       }
@@ -2210,13 +2210,15 @@ var Aircraft=Fiber.extend(function() {
         this.destination = data.destination;
       }
 
-      if(data.speed) this.speed = data.speed;
       if(data.heading)  this.fms.setCurrent({heading: data.heading});
       if(data.altitude) this.fms.setCurrent({altitude: data.altitude});
       this.fms.setCurrent({speed: data.speed || this.model.speed.cruise});
-      if(data.route) {  // filed a STAR
+      if(data.route) {
         this.fms.customRoute(this.fms.formatRoute(data.route), true);
         this.fms.descendViaSTAR();
+      }
+      if(data.nextFix) {
+        this.fms.skipToFix(data.nextFix);
       }
     },
     pushHistory: function() {

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -136,8 +136,9 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
       // Spawn aircraft along the route, ahead of the standard spawn point
       for(var i in spawn_positions) {
         var airline = choose_weight(this.airlines);
+        var fleet = "";
         if(airline.indexOf('/') > -1) {
-          var fleet = airline.split('/')[1];
+          fleet = airline.split('/')[1];
           airline   = airline.split('/')[0];
         }
 

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -66,6 +66,97 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
         airline_get(data[0].split('/')[0]);
       });
     },
+    /** Backfill STAR routes with arrivals closer than the spawn point
+     ** Aircraft spawn at the first point defined in the route of the entry in
+     ** "arrivals" in the airport json file. When that spawn point is very far
+     ** from the airspace boundary, it obviously takes quite a while for them
+     ** to reach the airspace. This function spawns (all at once) arrivals along
+     ** the route, between the spawn point and the airspace boundary, in order to
+     ** ensure the player is not kept waiting for their first arrival aircraft.
+     */
+    preSpawn: function() {
+      var star, entry;
+      var runway = this.airport.runway;
+
+      //Find STAR & entry point
+      var pieces = array_clean(this.route.split('.'));
+      for(var i in pieces) {
+        if(this.airport.stars.hasOwnProperty(pieces[i])) {
+          star = pieces[i];
+          if(i>0) entry = pieces[i-1];
+        }
+      }
+
+      // Find the last fix that's outside the airspace boundary
+      var fixes = this.airport.getSTAR(star, entry, runway);
+      var lastFix = fixes[0][0];
+      var extra = 0;  // dist btwn closest fix outside a/s and a/s border, nm
+      for(var i in fixes) {
+        var fix = fixes[i][0];
+        var pos = this.airport.fixes[fix].position;
+        var fix_prev = (i>0) ? fixes[i-1][0] : fix;
+        var pos_prev = (i>0) ? this.airport.fixes[fix_prev].position : pos;
+        if(inAirspace(pos)) {
+          if(i>=1) extra = nm(dist_to_boundary(pos_prev));
+          break;
+        }
+        else fixes[i][2] = nm(distance2d(pos_prev, pos));  // calculate distance between fixes
+      }
+
+      // Determine spawn offsets
+      var spawn_offsets = [];
+      var entrail_dist = this.speed / this.frequency;   // distance between succ. arrivals, nm
+      var dist_total = array_sum($.map(fixes,function(v){return v[2]})) + extra;
+      for(var i=entrail_dist; i<dist_total; i+=entrail_dist) {
+        spawn_offsets.push(i);
+      }
+
+      // Determine spawn points
+      var spawn_positions = [];
+      for(var i in spawn_offsets) { // for each new aircraft
+        for(var j=1; j<fixes.length; j++) { // for each fix ahead
+          if(spawn_offsets[i] > fixes[j][2]) {  // if point beyond next fix
+            spawn_offsets[i] -= fixes[j][2];
+            continue;
+          }
+          else {  // if point before next fix
+            var next = airport_get().fixes[fixes[j][0]];
+            var prev = airport_get().fixes[fixes[j-1][0]];
+            var brng = bearing(prev.gps, next.gps);
+            spawn_positions.push({
+              pos: fixRadialDist(prev.gps, brng, spawn_offsets[i]),
+              nextFix: fixes[j][0],
+              heading: brng
+            });
+            break;
+          }
+        }
+      }
+
+      // Spawn aircraft along the route, ahead of the standard spawn point
+      for(var i in spawn_positions) {
+        var airline = choose_weight(this.airlines);
+        if(airline.indexOf('/') > -1) {
+          var fleet = airline.split('/')[1];
+          airline   = airline.split('/')[0];
+        }
+
+        aircraft_new({
+          category:  "arrival",
+          destination:airport_get().icao,
+          airline:   airline,
+          fleet:     fleet,
+          altitude:  10000, // should eventually look up altitude restrictions and try to spawn in an appropriate range
+          heading:   spawn_positions[i].heading || this.heading,
+          waypoints: this.fixes,
+          route:     this.route,
+          position:  new Position(spawn_positions[i].pos, airport_get().position, airport_get().magnetic_north, 'GPS').position,
+          speed:     this.speed,
+          nextFix:   spawn_positions[i].nextFix
+        });
+      }
+
+    },
     /** Stop this arrival stream
      */
     stop: function() {
@@ -76,6 +167,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
     start: function() {
       var delay = random(0, 3600 / this.frequency);
       this.timeout = game_timeout(this.spawnAircraft, delay, this, [true, true]);
+      this.preSpawn();
     },
     /** Spawn a new aircraft
      */
@@ -726,14 +818,9 @@ var Airport=Fiber.extend(function() {
 
       if(data.fixes) {
         for(var i in data.fixes) {
-          var name = i.toUpperCase(),
-              coord = new Position(data.fixes[i],
-                                   this.position,
-                                   this.magnetic_north);
-          this.fixes[name] = coord.position;
-          if (i.indexOf('_') != 0) {
-            this.real_fixes[name] = coord.position;
-          }
+          var name = i.toUpperCase();
+          this.fixes[name] = new Position(data.fixes[i], this.position, this.magnetic_north);
+          if(i.indexOf('_') != 0) this.real_fixes[name] = this.fixes[name];
         }
       }
 
@@ -782,7 +869,7 @@ var Airport=Fiber.extend(function() {
               coords_min = coords[0];
 
           for (var i in coords) {
-            var v = coords[i]; //.position;
+            var v = coords[i];
             coords_max = [Math.max(v[0], coords_max[0]), Math.max(v[1], coords_max[1])];
             coords_min = [Math.min(v[0], coords_min[0]), Math.min(v[1], coords_min[1])];
           };
@@ -1009,7 +1096,7 @@ var Airport=Fiber.extend(function() {
     getFix: function(name) {
       if(!name) return null;
       if(Object.keys(airport_get().fixes).indexOf(name.toUpperCase()) == -1) return;
-      else return airport_get().fixes[name.toUpperCase()];
+      else return airport_get().fixes[name.toUpperCase()].position;
     },
     getSID: function(id, trxn, rwy) {
       if(!(id && trxn && rwy)) return null;
@@ -1146,7 +1233,7 @@ var Airport=Fiber.extend(function() {
           }
           if(this.sids[s].hasOwnProperty("draw")) { // draw portion
             for(var i in this.sids[s].draw)
-              for(var j in this.sids[s].draw[i])
+              for(var j=0; j<this.sids[s].draw[i].length; j++)
                 fixes.push(this.sids[s].draw[i][j].replace('*',''));
           }
         }

--- a/assets/scripts/airport.js
+++ b/assets/scripts/airport.js
@@ -167,7 +167,7 @@ zlsa.atc.ArrivalBase = Fiber.extend(function(base) {
     start: function() {
       var delay = random(0, 3600 / this.frequency);
       this.timeout = game_timeout(this.spawnAircraft, delay, this, [true, true]);
-      this.preSpawn();
+      if(this.route) this.preSpawn();
     },
     /** Spawn a new aircraft
      */

--- a/assets/scripts/base.js
+++ b/assets/scripts/base.js
@@ -13,6 +13,7 @@ var Position=Fiber.extend(function() {
   return {
     // coordinates - Array containing offset pair or latitude/longitude pair
     // reference - Position to use for calculating offsets when lat/long given
+    // mode - optional. Set to "GPS" to indicate you are inputting lat/lon that should be converted to positions
     //
     // coordinates may contain an optional elevation as a third
     // element.  It must be suffixed by either 'ft' or 'm' to indicate
@@ -21,7 +22,7 @@ var Position=Fiber.extend(function() {
     //   Decimal degrees - 'N47.112388112'
     //   Decimal minutes - 'N38d38.109808'
     //   Decimal seconds - 'N58d27m12.138'
-    init: function(coordinates, reference, magnetic_north) {
+    init: function(coordinates, reference, magnetic_north, /*optional*/ mode) {
       if(!coordinates) coordinates=[];
 
       this.latitude = 0;
@@ -34,19 +35,22 @@ var Position=Fiber.extend(function() {
       this.x = 0;
       this.y = 0;
       this.position = [this.x, this.y];
+      this.gps = [0,0];
 
-      this.parse(coordinates);
+      this.parse(coordinates, mode);
     },
-    parse: function(coordinates) {
+    parse: function(coordinates, mode) {
       if (! /^[NESW]/.test(coordinates[0])) {
         this.x = coordinates[0];
         this.y = coordinates[1];
         this.position = [this.x, this.y];
+        if(mode === 'GPS') this.parse4326();
         return;
       }
 
       this.latitude = this.parseCoordinate(coordinates[0]);
       this.longitude = this.parseCoordinate(coordinates[1]);
+      this.gps = [this.longitude, this.latitude]; // GPS coordinates in [x,y] order
 
       if (coordinates[2] != null) {
         this.elevation = parseElevation(coordinates[2]);

--- a/assets/scripts/canvas.js
+++ b/assets/scripts/canvas.js
@@ -239,7 +239,7 @@ function canvas_draw_fixes(cc) {
   var airport=airport_get();
   for(var i in airport.real_fixes) {
     cc.save();
-    cc.translate(round(km_to_px(airport.fixes[i][0])) + prop.canvas.panX, -round(km_to_px(airport.fixes[i][1])) + prop.canvas.panY);
+    cc.translate(round(km_to_px(airport.fixes[i].position[0])) + prop.canvas.panX, -round(km_to_px(airport.fixes[i].position[1])) + prop.canvas.panY);
 
     // draw outline (draw with eraser)
     cc.strokeStyle = "rgba(0, 0, 0, 0.67)";
@@ -247,14 +247,14 @@ function canvas_draw_fixes(cc) {
     cc.globalCompositeOperation = 'destination-out';
     cc.lineWidth   = 4;
     
-    canvas_draw_fix(cc, i, airport.fixes[i]);
+    canvas_draw_fix(cc, i, airport.fixes[i].position);
 
     cc.strokeStyle = "rgba(255, 255, 255, 0)";
     cc.fillStyle   = "rgba(255, 255, 255, 0.5)";
     cc.globalCompositeOperation = 'source-over';
     cc.lineWidth   = 1;
 
-    canvas_draw_fix(cc, i, airport.fixes[i]);
+    canvas_draw_fix(cc, i, airport.fixes[i].position);
     cc.restore();
   }
 }


### PR DESCRIPTION
Finally resolves #551. Really sorry it took so long to get around to this one; it was an issue that was rather detrimental to gameplay... Anyway, this will fix it.

At the beginning of a new game, you will no longer have to wait for arrivals to reach the boundary if their spawn point is a long way away. Depending on the `frequency` set in the arrival stream, if there is enough room to add plane(s) _between_ the spawn point and the airspace boundary, the game will now do so.

An example is at Miami, where we put in the full STARs, including entry points hundreds of miles from the airspace boundary. Used to be that it would take as much as 10-15 minutes to get the stream spawning the furthest away to actually reach the airspace. Below I've provided a screenshot that shows the aircraft that are spawned beyond the spawn point, up to the airspace boundary. As indicated in the console, this screenshot was taken about 4 seconds into a new simulation session.

![image](https://cloud.githubusercontent.com/assets/5103735/17026019/98de4ecc-4f2c-11e6-92a8-5532cbbe4cba.png)
