### PR TITLE
Fix asterisk shortkey (land) and add del/fph commands

### DIFF
--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1566,6 +1566,7 @@ var Aircraft=Fiber.extend(function() {
       clearedAsFiled: 'runClearedAsFiled',
       climbViaSID: 'runClimbViaSID',
       debug: 'runDebug',
+      delete: 'runDelete',
       descendViaSTAR: 'runDescendViaSTAR',
       direct: 'runDirect',
       fix: 'runFix',
@@ -2154,6 +2155,9 @@ var Aircraft=Fiber.extend(function() {
     runDebug: function() {
       window.aircraft = this;
       return ["ok", {log:"in the console, look at the variable &lsquo;aircraft&rsquo;", say:""}];
+    },
+    runDelete: function() {
+      aircraft_remove(this);
     },
     cancelFix: function() {
       if(this.fms.currentWaypoint().navmode == "fix") {
@@ -3102,10 +3106,7 @@ function aircraft_update() {
       }
     }
     if(remove) {
-      aircraft.cleanup();
-      prop.aircraft.callsigns.splice(prop.aircraft.callsigns.indexOf(aircraft.callsign), 1);
-      prop.aircraft.list.splice(i, 1);
-      update_aircraft_eids();
+      aircraft_remove(aircraft);
       i-=1;
     }
   }

--- a/assets/scripts/aircraft.js
+++ b/assets/scripts/aircraft.js
@@ -1570,6 +1570,7 @@ var Aircraft=Fiber.extend(function() {
       descendViaSTAR: 'runDescendViaSTAR',
       direct: 'runDirect',
       fix: 'runFix',
+      flyPresentHeading: 'runFlyPresentHeading',
       heading: 'runHeading',
       hold: 'runHold',
       land: 'runLanding',
@@ -1961,6 +1962,11 @@ var Aircraft=Fiber.extend(function() {
         this.cancelLanding();
       }
       return ["ok", "proceed direct " + fixes.join(', ')];
+    },
+    runFlyPresentHeading: function(data) {
+      this.cancelFix();
+      this.runHeading([null, degrees(this.heading)]);
+      return ["ok", "fly present heading"];
     },
     runSayRoute: function(data) {
       return ['ok', {log:'route: ' + this.fms.fp.route.join(' '), say:"here's our route"}];

--- a/assets/scripts/input.js
+++ b/assets/scripts/input.js
@@ -358,7 +358,7 @@ function input_history_next() {
 function input_run() {
   var result;
   try {
-    result = zlsa.atc.Parser.parse(prop.input.command.trim());
+    result = zlsa.atc.Parser.parse(prop.input.command.trim().toLowerCase());
   }
   catch (e) {
     if (e.hasOwnProperty('name') && e.name == 'SyntaxError') {

--- a/assets/scripts/parser.js
+++ b/assets/scripts/parser.js
@@ -109,144 +109,151 @@ zlsa.atc.Parser = (function() {
         peg$c70 = "log",
         peg$c71 = { type: "literal", value: "log", description: "\"log\"" },
         peg$c72 = function() {return ["debug"]},
-        peg$c73 = "descendviastar",
-        peg$c74 = { type: "literal", value: "descendviastar", description: "\"descendviastar\"" },
-        peg$c75 = "dvs",
-        peg$c76 = { type: "literal", value: "dvs", description: "\"dvs\"" },
-        peg$c77 = function() {return ["descendViaSTAR"]},
-        peg$c78 = "direct",
-        peg$c79 = { type: "literal", value: "direct", description: "\"direct\"" },
-        peg$c80 = "dct",
-        peg$c81 = { type: "literal", value: "dct", description: "\"dct\"" },
-        peg$c82 = "pd",
-        peg$c83 = { type: "literal", value: "pd", description: "\"pd\"" },
-        peg$c84 = function() {return "direct"},
-        peg$c85 = "fix",
-        peg$c86 = { type: "literal", value: "fix", description: "\"fix\"" },
-        peg$c87 = "f",
-        peg$c88 = { type: "literal", value: "f", description: "\"f\"" },
-        peg$c89 = "track",
-        peg$c90 = { type: "literal", value: "track", description: "\"track\"" },
-        peg$c91 = function() {return "fix"},
-        peg$c92 = function(cmd) { return [cmd[0], cmd[1], cmd[2][0], cmd[2][1]] },
-        peg$c93 = "\u2BA2",
-        peg$c94 = { type: "literal", value: "\u2BA2", description: "\"\\u2BA2\"" },
-        peg$c95 = function() {return "left"},
-        peg$c96 = "\u2BA3",
-        peg$c97 = { type: "literal", value: "\u2BA3", description: "\"\\u2BA3\"" },
-        peg$c98 = function() {return "right"},
-        peg$c99 = "fh",
-        peg$c100 = { type: "literal", value: "fh", description: "\"fh\"" },
-        peg$c101 = function() {return null},
-        peg$c102 = function(dir, arg) {return ['heading', dir, arg]},
-        peg$c103 = "heading",
-        peg$c104 = { type: "literal", value: "heading", description: "\"heading\"" },
-        peg$c105 = "turn",
-        peg$c106 = { type: "literal", value: "turn", description: "\"turn\"" },
-        peg$c107 = "t",
-        peg$c108 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c109 = "h",
-        peg$c110 = { type: "literal", value: "h", description: "\"h\"" },
-        peg$c111 = function() {return "heading"},
-        peg$c112 = function(arg) {return arg},
-        peg$c113 = /^[0-9]/,
-        peg$c114 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c115 = function() {return [parseInt(text()), false]},
-        peg$c116 = function() {return [parseInt(text()), true]},
-        peg$c117 = "hold",
-        peg$c118 = { type: "literal", value: "hold", description: "\"hold\"" },
-        peg$c119 = "min",
-        peg$c120 = { type: "literal", value: "min", description: "\"min\"" },
-        peg$c121 = "nm",
-        peg$c122 = { type: "literal", value: "nm", description: "\"nm\"" },
-        peg$c123 = function(dir, length, fix) {return ["hold",
+        peg$c73 = "delete",
+        peg$c74 = { type: "literal", value: "delete", description: "\"delete\"" },
+        peg$c75 = "del",
+        peg$c76 = { type: "literal", value: "del", description: "\"del\"" },
+        peg$c77 = "kill",
+        peg$c78 = { type: "literal", value: "kill", description: "\"kill\"" },
+        peg$c79 = function() {return ["delete"]},
+        peg$c80 = "descendviastar",
+        peg$c81 = { type: "literal", value: "descendviastar", description: "\"descendviastar\"" },
+        peg$c82 = "dvs",
+        peg$c83 = { type: "literal", value: "dvs", description: "\"dvs\"" },
+        peg$c84 = function() {return ["descendViaSTAR"]},
+        peg$c85 = "direct",
+        peg$c86 = { type: "literal", value: "direct", description: "\"direct\"" },
+        peg$c87 = "dct",
+        peg$c88 = { type: "literal", value: "dct", description: "\"dct\"" },
+        peg$c89 = "pd",
+        peg$c90 = { type: "literal", value: "pd", description: "\"pd\"" },
+        peg$c91 = function() {return "direct"},
+        peg$c92 = "fix",
+        peg$c93 = { type: "literal", value: "fix", description: "\"fix\"" },
+        peg$c94 = "f",
+        peg$c95 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c96 = "track",
+        peg$c97 = { type: "literal", value: "track", description: "\"track\"" },
+        peg$c98 = function() {return "fix"},
+        peg$c99 = function(cmd) { return [cmd[0], cmd[1], cmd[2][0], cmd[2][1]] },
+        peg$c100 = "\u2BA2",
+        peg$c101 = { type: "literal", value: "\u2BA2", description: "\"\\u2BA2\"" },
+        peg$c102 = function() {return "left"},
+        peg$c103 = "\u2BA3",
+        peg$c104 = { type: "literal", value: "\u2BA3", description: "\"\\u2BA3\"" },
+        peg$c105 = function() {return "right"},
+        peg$c106 = "fh",
+        peg$c107 = { type: "literal", value: "fh", description: "\"fh\"" },
+        peg$c108 = function() {return null},
+        peg$c109 = function(dir, arg) {return ['heading', dir, arg]},
+        peg$c110 = "heading",
+        peg$c111 = { type: "literal", value: "heading", description: "\"heading\"" },
+        peg$c112 = "turn",
+        peg$c113 = { type: "literal", value: "turn", description: "\"turn\"" },
+        peg$c114 = "t",
+        peg$c115 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c116 = "h",
+        peg$c117 = { type: "literal", value: "h", description: "\"h\"" },
+        peg$c118 = function() {return "heading"},
+        peg$c119 = function(arg) {return arg},
+        peg$c120 = /^[0-9]/,
+        peg$c121 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c122 = function() {return [parseInt(text()), false]},
+        peg$c123 = function() {return [parseInt(text()), true]},
+        peg$c124 = "hold",
+        peg$c125 = { type: "literal", value: "hold", description: "\"hold\"" },
+        peg$c126 = "min",
+        peg$c127 = { type: "literal", value: "min", description: "\"min\"" },
+        peg$c128 = "nm",
+        peg$c129 = { type: "literal", value: "nm", description: "\"nm\"" },
+        peg$c130 = function(dir, length, fix) {return ["hold",
                      dir,
                      length ? length[1] + length[2] : null,
                      fix ? fix[2] : null]},
-        peg$c124 = function(cmd) {return [cmd[0], cmd[1], cmd[2]]},
-        peg$c125 = "land",
-        peg$c126 = { type: "literal", value: "land", description: "\"land\"" },
-        peg$c127 = "l",
-        peg$c128 = { type: "literal", value: "l", description: "\"l\"" },
-        peg$c129 = "ils",
-        peg$c130 = { type: "literal", value: "ils", description: "\"ils\"" },
-        peg$c131 = function() {return "land"},
-        peg$c132 = /^[a-z]/i,
-        peg$c133 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
-        peg$c134 = function(cmd, variant, arg) {return [variant, arg]},
-        peg$c135 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
-        peg$c136 = "\u2B50",
-        peg$c137 = { type: "literal", value: "\u2B50", description: "\"\\u2B50\"" },
-        peg$c138 = "movedatablock",
-        peg$c139 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
-        peg$c140 = "`",
-        peg$c141 = { type: "literal", value: "`", description: "\"`\"" },
-        peg$c142 = function() {return "moveDataBlock"},
-        peg$c143 = /^[1-9]/,
-        peg$c144 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c145 = "route",
-        peg$c146 = { type: "literal", value: "route", description: "\"route\"" },
-        peg$c147 = function(arg) {return ["route", arg]},
-        peg$c148 = "reroute",
-        peg$c149 = { type: "literal", value: "reroute", description: "\"reroute\"" },
-        peg$c150 = "rr",
-        peg$c151 = { type: "literal", value: "rr", description: "\"rr\"" },
-        peg$c152 = function(arg) {return ["reroute", arg]},
-        peg$c153 = "sayroute",
-        peg$c154 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
-        peg$c155 = "sr",
-        peg$c156 = { type: "literal", value: "sr", description: "\"sr\"" },
-        peg$c157 = function() {return ["sayRoute"]},
-        peg$c158 = "sid",
-        peg$c159 = { type: "literal", value: "sid", description: "\"sid\"" },
-        peg$c160 = function(arg) {return ["sid", arg]},
-        peg$c161 = "+",
-        peg$c162 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c163 = "-",
-        peg$c164 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c165 = "speed",
-        peg$c166 = { type: "literal", value: "speed", description: "\"speed\"" },
-        peg$c167 = "slow",
-        peg$c168 = { type: "literal", value: "slow", description: "\"slow\"" },
-        peg$c169 = "sp",
-        peg$c170 = { type: "literal", value: "sp", description: "\"sp\"" },
-        peg$c171 = function() {return "speed"},
-        peg$c172 = "star",
-        peg$c173 = { type: "literal", value: "star", description: "\"star\"" },
-        peg$c174 = function(arg) {return ["star", arg]},
-        peg$c175 = "takeoff",
-        peg$c176 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
-        peg$c177 = "to",
-        peg$c178 = { type: "literal", value: "to", description: "\"to\"" },
-        peg$c179 = "cto",
-        peg$c180 = { type: "literal", value: "cto", description: "\"cto\"" },
-        peg$c181 = function() {return ["takeoff"]},
-        peg$c182 = "taxi",
-        peg$c183 = { type: "literal", value: "taxi", description: "\"taxi\"" },
-        peg$c184 = "wait",
-        peg$c185 = { type: "literal", value: "wait", description: "\"wait\"" },
-        peg$c186 = "w",
-        peg$c187 = { type: "literal", value: "w", description: "\"w\"" },
-        peg$c188 = function(runway) {return ["taxi", runway]},
-        peg$c189 = "left",
-        peg$c190 = { type: "literal", value: "left", description: "\"left\"" },
-        peg$c191 = "right",
-        peg$c192 = { type: "literal", value: "right", description: "\"right\"" },
-        peg$c193 = "r",
-        peg$c194 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c195 = function(dir) {return dir},
-        peg$c196 = function(fix) {return fix[2]},
-        peg$c197 = /^[ \t]/,
-        peg$c198 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
-        peg$c199 = ".",
-        peg$c200 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c201 = function() {
+        peg$c131 = function(cmd) {return [cmd[0], cmd[1], cmd[2]]},
+        peg$c132 = "land",
+        peg$c133 = { type: "literal", value: "land", description: "\"land\"" },
+        peg$c134 = "l",
+        peg$c135 = { type: "literal", value: "l", description: "\"l\"" },
+        peg$c136 = "ils",
+        peg$c137 = { type: "literal", value: "ils", description: "\"ils\"" },
+        peg$c138 = function() {return "land"},
+        peg$c139 = /^[a-z]/i,
+        peg$c140 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
+        peg$c141 = function(cmd, variant, arg) {return [variant, arg]},
+        peg$c142 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
+        peg$c143 = "\u2B50",
+        peg$c144 = { type: "literal", value: "\u2B50", description: "\"\\u2B50\"" },
+        peg$c145 = "movedatablock",
+        peg$c146 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
+        peg$c147 = "`",
+        peg$c148 = { type: "literal", value: "`", description: "\"`\"" },
+        peg$c149 = function() {return "moveDataBlock"},
+        peg$c150 = /^[1-9]/,
+        peg$c151 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c152 = "route",
+        peg$c153 = { type: "literal", value: "route", description: "\"route\"" },
+        peg$c154 = function(arg) {return ["route", arg]},
+        peg$c155 = "reroute",
+        peg$c156 = { type: "literal", value: "reroute", description: "\"reroute\"" },
+        peg$c157 = "rr",
+        peg$c158 = { type: "literal", value: "rr", description: "\"rr\"" },
+        peg$c159 = function(arg) {return ["reroute", arg]},
+        peg$c160 = "sayroute",
+        peg$c161 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
+        peg$c162 = "sr",
+        peg$c163 = { type: "literal", value: "sr", description: "\"sr\"" },
+        peg$c164 = function() {return ["sayRoute"]},
+        peg$c165 = "sid",
+        peg$c166 = { type: "literal", value: "sid", description: "\"sid\"" },
+        peg$c167 = function(arg) {return ["sid", arg]},
+        peg$c168 = "+",
+        peg$c169 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c170 = "-",
+        peg$c171 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c172 = "speed",
+        peg$c173 = { type: "literal", value: "speed", description: "\"speed\"" },
+        peg$c174 = "slow",
+        peg$c175 = { type: "literal", value: "slow", description: "\"slow\"" },
+        peg$c176 = "sp",
+        peg$c177 = { type: "literal", value: "sp", description: "\"sp\"" },
+        peg$c178 = function() {return "speed"},
+        peg$c179 = "star",
+        peg$c180 = { type: "literal", value: "star", description: "\"star\"" },
+        peg$c181 = function(arg) {return ["star", arg]},
+        peg$c182 = "takeoff",
+        peg$c183 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
+        peg$c184 = "to",
+        peg$c185 = { type: "literal", value: "to", description: "\"to\"" },
+        peg$c186 = "cto",
+        peg$c187 = { type: "literal", value: "cto", description: "\"cto\"" },
+        peg$c188 = function() {return ["takeoff"]},
+        peg$c189 = "taxi",
+        peg$c190 = { type: "literal", value: "taxi", description: "\"taxi\"" },
+        peg$c191 = "wait",
+        peg$c192 = { type: "literal", value: "wait", description: "\"wait\"" },
+        peg$c193 = "w",
+        peg$c194 = { type: "literal", value: "w", description: "\"w\"" },
+        peg$c195 = function(runway) {return ["taxi", runway]},
+        peg$c196 = "left",
+        peg$c197 = { type: "literal", value: "left", description: "\"left\"" },
+        peg$c198 = "right",
+        peg$c199 = { type: "literal", value: "right", description: "\"right\"" },
+        peg$c200 = "r",
+        peg$c201 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c202 = function(dir) {return dir},
+        peg$c203 = function(fix) {return fix[2]},
+        peg$c204 = /^[ \t]/,
+        peg$c205 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
+        peg$c206 = ".",
+        peg$c207 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c208 = function() {
             return parseFloat(text());
           },
-        peg$c202 = /^[a-zA-Z0-9.]/,
-        peg$c203 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
-        peg$c204 = { type: "other", description: "whiteSpace" },
-        peg$c205 = function(arg) {return parseInt(arg)},
+        peg$c209 = /^[a-zA-Z0-9.]/,
+        peg$c210 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
+        peg$c211 = { type: "other", description: "whiteSpace" },
+        peg$c212 = function(arg) {return parseInt(arg)},
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -750,33 +757,36 @@ zlsa.atc.Parser = (function() {
                 if (s3 === peg$FAILED) {
                   s3 = peg$parsecmdDebug();
                   if (s3 === peg$FAILED) {
-                    s3 = peg$parsecmdDescendViaSTAR();
+                    s3 = peg$parsecmdDelete();
                     if (s3 === peg$FAILED) {
-                      s3 = peg$parsecmdFix();
+                      s3 = peg$parsecmdDescendViaSTAR();
                       if (s3 === peg$FAILED) {
-                        s3 = peg$parsecmdHeading();
+                        s3 = peg$parsecmdFix();
                         if (s3 === peg$FAILED) {
-                          s3 = peg$parsecmdHold();
+                          s3 = peg$parsecmdHeading();
                           if (s3 === peg$FAILED) {
-                            s3 = peg$parsecmdLand();
+                            s3 = peg$parsecmdHold();
                             if (s3 === peg$FAILED) {
-                              s3 = peg$parsecmdMoveDataBlock();
+                              s3 = peg$parsecmdLand();
                               if (s3 === peg$FAILED) {
-                                s3 = peg$parsecmdRoute();
+                                s3 = peg$parsecmdMoveDataBlock();
                                 if (s3 === peg$FAILED) {
-                                  s3 = peg$parsecmdReRoute();
+                                  s3 = peg$parsecmdRoute();
                                   if (s3 === peg$FAILED) {
-                                    s3 = peg$parsecmdSayRoute();
+                                    s3 = peg$parsecmdReRoute();
                                     if (s3 === peg$FAILED) {
-                                      s3 = peg$parsecmdSID();
+                                      s3 = peg$parsecmdSayRoute();
                                       if (s3 === peg$FAILED) {
-                                        s3 = peg$parsecmdSpeed();
+                                        s3 = peg$parsecmdSID();
                                         if (s3 === peg$FAILED) {
-                                          s3 = peg$parsecmdSTAR();
+                                          s3 = peg$parsecmdSpeed();
                                           if (s3 === peg$FAILED) {
-                                            s3 = peg$parsecmdTakeoff();
+                                            s3 = peg$parsecmdSTAR();
                                             if (s3 === peg$FAILED) {
-                                              s3 = peg$parsecmdTaxi();
+                                              s3 = peg$parsecmdTakeoff();
+                                              if (s3 === peg$FAILED) {
+                                                s3 = peg$parsecmdTaxi();
+                                              }
                                             }
                                           }
                                         }
@@ -826,33 +836,36 @@ zlsa.atc.Parser = (function() {
                     if (s3 === peg$FAILED) {
                       s3 = peg$parsecmdDebug();
                       if (s3 === peg$FAILED) {
-                        s3 = peg$parsecmdDescendViaSTAR();
+                        s3 = peg$parsecmdDelete();
                         if (s3 === peg$FAILED) {
-                          s3 = peg$parsecmdFix();
+                          s3 = peg$parsecmdDescendViaSTAR();
                           if (s3 === peg$FAILED) {
-                            s3 = peg$parsecmdHeading();
+                            s3 = peg$parsecmdFix();
                             if (s3 === peg$FAILED) {
-                              s3 = peg$parsecmdHold();
+                              s3 = peg$parsecmdHeading();
                               if (s3 === peg$FAILED) {
-                                s3 = peg$parsecmdLand();
+                                s3 = peg$parsecmdHold();
                                 if (s3 === peg$FAILED) {
-                                  s3 = peg$parsecmdMoveDataBlock();
+                                  s3 = peg$parsecmdLand();
                                   if (s3 === peg$FAILED) {
-                                    s3 = peg$parsecmdRoute();
+                                    s3 = peg$parsecmdMoveDataBlock();
                                     if (s3 === peg$FAILED) {
-                                      s3 = peg$parsecmdReRoute();
+                                      s3 = peg$parsecmdRoute();
                                       if (s3 === peg$FAILED) {
-                                        s3 = peg$parsecmdSayRoute();
+                                        s3 = peg$parsecmdReRoute();
                                         if (s3 === peg$FAILED) {
-                                          s3 = peg$parsecmdSID();
+                                          s3 = peg$parsecmdSayRoute();
                                           if (s3 === peg$FAILED) {
-                                            s3 = peg$parsecmdSpeed();
+                                            s3 = peg$parsecmdSID();
                                             if (s3 === peg$FAILED) {
-                                              s3 = peg$parsecmdSTAR();
+                                              s3 = peg$parsecmdSpeed();
                                               if (s3 === peg$FAILED) {
-                                                s3 = peg$parsecmdTakeoff();
+                                                s3 = peg$parsecmdSTAR();
                                                 if (s3 === peg$FAILED) {
-                                                  s3 = peg$parsecmdTaxi();
+                                                  s3 = peg$parsecmdTakeoff();
+                                                  if (s3 === peg$FAILED) {
+                                                    s3 = peg$parsecmdTaxi();
+                                                  }
                                                 }
                                               }
                                             }
@@ -1203,13 +1216,13 @@ zlsa.atc.Parser = (function() {
       return s0;
     }
 
-    function peg$parsecmdDescendViaSTAR() {
+    function peg$parsecmdDelete() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 14) === peg$c73) {
+      if (input.substr(peg$currPos, 6) === peg$c73) {
         s1 = peg$c73;
-        peg$currPos += 14;
+        peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c74); }
@@ -1222,10 +1235,48 @@ zlsa.atc.Parser = (function() {
           s1 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 4) === peg$c77) {
+            s1 = peg$c77;
+            peg$currPos += 4;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          }
+        }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77();
+        s1 = peg$c79();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsecmdDescendViaSTAR() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 14) === peg$c80) {
+        s1 = peg$c80;
+        peg$currPos += 14;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 3) === peg$c82) {
+          s1 = peg$c82;
+          peg$currPos += 3;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c84();
       }
       s0 = s1;
 
@@ -1237,34 +1288,34 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c78) {
-        s2 = peg$c78;
+      if (input.substr(peg$currPos, 6) === peg$c85) {
+        s2 = peg$c85;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        if (peg$silentFails === 0) { peg$fail(peg$c86); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c80) {
-          s2 = peg$c80;
+        if (input.substr(peg$currPos, 3) === peg$c87) {
+          s2 = peg$c87;
           peg$currPos += 3;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c82) {
-            s2 = peg$c82;
+          if (input.substr(peg$currPos, 2) === peg$c89) {
+            s2 = peg$c89;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c83); }
+            if (peg$silentFails === 0) { peg$fail(peg$c90); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c84();
+        s2 = peg$c91();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -1289,34 +1340,34 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c85) {
-        s2 = peg$c85;
+      if (input.substr(peg$currPos, 3) === peg$c92) {
+        s2 = peg$c92;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 102) {
-          s2 = peg$c87;
+          s2 = peg$c94;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c88); }
+          if (peg$silentFails === 0) { peg$fail(peg$c95); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 5) === peg$c89) {
-            s2 = peg$c89;
+          if (input.substr(peg$currPos, 5) === peg$c96) {
+            s2 = peg$c96;
             peg$currPos += 5;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c90); }
+            if (peg$silentFails === 0) { peg$fail(peg$c97); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c91();
+        s2 = peg$c98();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -1355,7 +1406,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1);
+        s1 = peg$c99(s1);
       }
       s0 = s1;
 
@@ -1368,43 +1419,43 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 11170) {
-        s2 = peg$c93;
+        s2 = peg$c100;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c95();
+        s2 = peg$c102();
       }
       s1 = s2;
       if (s1 === peg$FAILED) {
         s1 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 11171) {
-          s2 = peg$c96;
+          s2 = peg$c103;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+          if (peg$silentFails === 0) { peg$fail(peg$c104); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c98();
+          s2 = peg$c105();
         }
         s1 = s2;
         if (s1 === peg$FAILED) {
           s1 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c99) {
-            s2 = peg$c99;
+          if (input.substr(peg$currPos, 2) === peg$c106) {
+            s2 = peg$c106;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s1;
-            s2 = peg$c101();
+            s2 = peg$c108();
           }
           s1 = s2;
         }
@@ -1413,7 +1464,7 @@ zlsa.atc.Parser = (function() {
         s2 = peg$parseargHeading();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102(s1, s2);
+          s1 = peg$c109(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1432,43 +1483,43 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c103) {
-        s2 = peg$c103;
+      if (input.substr(peg$currPos, 7) === peg$c110) {
+        s2 = peg$c110;
         peg$currPos += 7;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c105) {
-          s2 = peg$c105;
+        if (input.substr(peg$currPos, 4) === peg$c112) {
+          s2 = peg$c112;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c106); }
+          if (peg$silentFails === 0) { peg$fail(peg$c113); }
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 116) {
-            s2 = peg$c107;
+            s2 = peg$c114;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c115); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 104) {
-              s2 = peg$c109;
+              s2 = peg$c116;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c110); }
+              if (peg$silentFails === 0) { peg$fail(peg$c117); }
             }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c111();
+        s2 = peg$c118();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -1483,7 +1534,7 @@ zlsa.atc.Parser = (function() {
             s5 = peg$parseargHeading();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c112(s5);
+              s4 = peg$c119(s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -1516,32 +1567,32 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (peg$c113.test(input.charAt(peg$currPos))) {
+      if (peg$c120.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c113.test(input.charAt(peg$currPos))) {
+        if (peg$c120.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s2 !== peg$FAILED) {
-          if (peg$c113.test(input.charAt(peg$currPos))) {
+          if (peg$c120.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            if (peg$silentFails === 0) { peg$fail(peg$c121); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c115();
+            s1 = peg$c122();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1557,24 +1608,24 @@ zlsa.atc.Parser = (function() {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c113.test(input.charAt(peg$currPos))) {
+        if (peg$c120.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c113.test(input.charAt(peg$currPos))) {
+          if (peg$c120.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            if (peg$silentFails === 0) { peg$fail(peg$c121); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c116();
+            s1 = peg$c123();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1593,12 +1644,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c117) {
-        s1 = peg$c117;
+      if (input.substr(peg$currPos, 4) === peg$c124) {
+        s1 = peg$c124;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedirection();
@@ -1611,20 +1662,20 @@ zlsa.atc.Parser = (function() {
           if (s4 !== peg$FAILED) {
             s5 = peg$parseinteger();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c119) {
-                s6 = peg$c119;
+              if (input.substr(peg$currPos, 3) === peg$c126) {
+                s6 = peg$c126;
                 peg$currPos += 3;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c127); }
               }
               if (s6 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c121) {
-                  s6 = peg$c121;
+                if (input.substr(peg$currPos, 2) === peg$c128) {
+                  s6 = peg$c128;
                   peg$currPos += 2;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c122); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c129); }
                 }
               }
               if (s6 !== peg$FAILED) {
@@ -1681,7 +1732,7 @@ zlsa.atc.Parser = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c123(s2, s3, s4);
+              s1 = peg$c130(s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1713,7 +1764,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c124(s1);
+        s1 = peg$c131(s1);
       }
       s0 = s1;
 
@@ -1725,46 +1776,46 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c125) {
-        s2 = peg$c125;
+      if (input.substr(peg$currPos, 4) === peg$c132) {
+        s2 = peg$c132;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c126); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 108) {
-          s2 = peg$c127;
+          s2 = peg$c134;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c128); }
+          if (peg$silentFails === 0) { peg$fail(peg$c135); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c129) {
-            s2 = peg$c129;
+          if (input.substr(peg$currPos, 3) === peg$c136) {
+            s2 = peg$c136;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c130); }
+            if (peg$silentFails === 0) { peg$fail(peg$c137); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c131();
+        s2 = peg$c138();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = peg$parsewhiteSpace();
         if (s3 !== peg$FAILED) {
-          if (peg$c132.test(input.charAt(peg$currPos))) {
+          if (peg$c139.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+            if (peg$silentFails === 0) { peg$fail(peg$c140); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -1773,7 +1824,7 @@ zlsa.atc.Parser = (function() {
             s5 = peg$parsestring();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c134(s1, s4, s5);
+              s3 = peg$c141(s1, s4, s5);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1789,7 +1840,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c135(s1, s2);
+          s1 = peg$c142(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1809,25 +1860,25 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 11088) {
-        s2 = peg$c136;
+        s2 = peg$c143;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c144); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c131();
+        s2 = peg$c138();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c132.test(input.charAt(peg$currPos))) {
+        if (peg$c139.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+          if (peg$silentFails === 0) { peg$fail(peg$c140); }
         }
         if (s3 === peg$FAILED) {
           s3 = null;
@@ -1836,7 +1887,7 @@ zlsa.atc.Parser = (function() {
           s4 = peg$parsestring();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c134(s1, s3, s4);
+            s3 = peg$c141(s1, s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1848,7 +1899,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c135(s1, s2);
+          s1 = peg$c142(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1868,12 +1919,12 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       s2 = peg$currPos;
-      if (input.substr(peg$currPos, 13) === peg$c138) {
-        s3 = peg$c138;
+      if (input.substr(peg$currPos, 13) === peg$c145) {
+        s3 = peg$c145;
         peg$currPos += 13;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c139); }
+        if (peg$silentFails === 0) { peg$fail(peg$c146); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsewhiteSpace();
@@ -1890,25 +1941,25 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 96) {
-          s2 = peg$c140;
+          s2 = peg$c147;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c148); }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c142();
+        s2 = peg$c149();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
-        if (peg$c143.test(input.charAt(peg$currPos))) {
+        if (peg$c150.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c144); }
+          if (peg$silentFails === 0) { peg$fail(peg$c151); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -1929,12 +1980,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c145) {
-        s1 = peg$c145;
+      if (input.substr(peg$currPos, 5) === peg$c152) {
+        s1 = peg$c152;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c146); }
+        if (peg$silentFails === 0) { peg$fail(peg$c153); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1942,7 +1993,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c147(s3);
+            s1 = peg$c154(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1964,20 +2015,20 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c148) {
-        s1 = peg$c148;
+      if (input.substr(peg$currPos, 7) === peg$c155) {
+        s1 = peg$c155;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c149); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c150) {
-          s1 = peg$c150;
+        if (input.substr(peg$currPos, 2) === peg$c157) {
+          s1 = peg$c157;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c151); }
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -1986,7 +2037,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c152(s3);
+            s1 = peg$c159(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2008,25 +2059,25 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c153) {
-        s1 = peg$c153;
+      if (input.substr(peg$currPos, 8) === peg$c160) {
+        s1 = peg$c160;
         peg$currPos += 8;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c154); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c155) {
-          s1 = peg$c155;
+        if (input.substr(peg$currPos, 2) === peg$c162) {
+          s1 = peg$c162;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c156); }
+          if (peg$silentFails === 0) { peg$fail(peg$c163); }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c157();
+        s1 = peg$c164();
       }
       s0 = s1;
 
@@ -2037,12 +2088,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c158) {
-        s1 = peg$c158;
+      if (input.substr(peg$currPos, 3) === peg$c165) {
+        s1 = peg$c165;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2050,7 +2101,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c160(s3);
+            s1 = peg$c167(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2074,45 +2125,45 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s2 = peg$c161;
+        s2 = peg$c168;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c162); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s2 = peg$c163;
+          s2 = peg$c170;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c164); }
+          if (peg$silentFails === 0) { peg$fail(peg$c171); }
         }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 5) === peg$c165) {
-          s3 = peg$c165;
+        if (input.substr(peg$currPos, 5) === peg$c172) {
+          s3 = peg$c172;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c166); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s3 === peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c167) {
-            s3 = peg$c167;
+          if (input.substr(peg$currPos, 4) === peg$c174) {
+            s3 = peg$c174;
             peg$currPos += 4;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c168); }
+            if (peg$silentFails === 0) { peg$fail(peg$c175); }
           }
           if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c169) {
-              s3 = peg$c169;
+            if (input.substr(peg$currPos, 2) === peg$c176) {
+              s3 = peg$c176;
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c170); }
+              if (peg$silentFails === 0) { peg$fail(peg$c177); }
             }
           }
         }
@@ -2132,7 +2183,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c171();
+        s2 = peg$c178();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -2156,12 +2207,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c172) {
-        s1 = peg$c172;
+      if (input.substr(peg$currPos, 4) === peg$c179) {
+        s1 = peg$c179;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c173); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2169,7 +2220,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s3);
+            s1 = peg$c181(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2191,34 +2242,34 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c175) {
-        s1 = peg$c175;
+      if (input.substr(peg$currPos, 7) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c176); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c177) {
-          s1 = peg$c177;
+        if (input.substr(peg$currPos, 2) === peg$c184) {
+          s1 = peg$c184;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c178); }
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c179) {
-            s1 = peg$c179;
+          if (input.substr(peg$currPos, 3) === peg$c186) {
+            s1 = peg$c186;
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c180); }
+            if (peg$silentFails === 0) { peg$fail(peg$c187); }
           }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c181();
+        s1 = peg$c188();
       }
       s0 = s1;
 
@@ -2229,28 +2280,28 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c182) {
-        s1 = peg$c182;
+      if (input.substr(peg$currPos, 4) === peg$c189) {
+        s1 = peg$c189;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c190); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c184) {
-          s1 = peg$c184;
+        if (input.substr(peg$currPos, 4) === peg$c191) {
+          s1 = peg$c191;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 119) {
-            s1 = peg$c186;
+            s1 = peg$c193;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c187); }
+            if (peg$silentFails === 0) { peg$fail(peg$c194); }
           }
         }
       }
@@ -2261,7 +2312,7 @@ zlsa.atc.Parser = (function() {
           s4 = peg$parsestring();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c112(s4);
+            s3 = peg$c119(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2276,7 +2327,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c188(s2);
+          s1 = peg$c195(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2297,54 +2348,54 @@ zlsa.atc.Parser = (function() {
       s1 = peg$parsewhiteSpace();
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c189) {
-          s3 = peg$c189;
+        if (input.substr(peg$currPos, 4) === peg$c196) {
+          s3 = peg$c196;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 108) {
-            s3 = peg$c127;
+            s3 = peg$c134;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+            if (peg$silentFails === 0) { peg$fail(peg$c135); }
           }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c95();
+          s3 = peg$c102();
         }
         s2 = s3;
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c191) {
-            s3 = peg$c191;
+          if (input.substr(peg$currPos, 5) === peg$c198) {
+            s3 = peg$c198;
             peg$currPos += 5;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c192); }
+            if (peg$silentFails === 0) { peg$fail(peg$c199); }
           }
           if (s3 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 114) {
-              s3 = peg$c193;
+              s3 = peg$c200;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c194); }
+              if (peg$silentFails === 0) { peg$fail(peg$c201); }
             }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c98();
+            s3 = peg$c105();
           }
           s2 = s3;
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c195(s2);
+          s1 = peg$c202(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2394,7 +2445,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c196(s1);
+        s1 = peg$c203(s1);
       }
       s0 = s1;
 
@@ -2406,22 +2457,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c197.test(input.charAt(peg$currPos))) {
+      if (peg$c204.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c197.test(input.charAt(peg$currPos))) {
+          if (peg$c204.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c198); }
+            if (peg$silentFails === 0) { peg$fail(peg$c205); }
           }
         }
       } else {
@@ -2443,33 +2494,33 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c163;
+        s3 = peg$c170;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c164); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c113.test(input.charAt(peg$currPos))) {
+        if (peg$c120.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c113.test(input.charAt(peg$currPos))) {
+            if (peg$c120.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c121); }
             }
           }
         } else {
@@ -2478,30 +2529,30 @@ zlsa.atc.Parser = (function() {
         if (s4 !== peg$FAILED) {
           s5 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s6 = peg$c199;
+            s6 = peg$c206;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c200); }
+            if (peg$silentFails === 0) { peg$fail(peg$c207); }
           }
           if (s6 !== peg$FAILED) {
             s7 = [];
-            if (peg$c113.test(input.charAt(peg$currPos))) {
+            if (peg$c120.test(input.charAt(peg$currPos))) {
               s8 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s8 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c121); }
             }
             if (s8 !== peg$FAILED) {
               while (s8 !== peg$FAILED) {
                 s7.push(s8);
-                if (peg$c113.test(input.charAt(peg$currPos))) {
+                if (peg$c120.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c121); }
                 }
               }
             } else {
@@ -2543,7 +2594,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c201();
+        s1 = peg$c208();
       }
       s0 = s1;
 
@@ -2555,22 +2606,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c202.test(input.charAt(peg$currPos))) {
+      if (peg$c209.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c203); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c202.test(input.charAt(peg$currPos))) {
+          if (peg$c209.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c203); }
+            if (peg$silentFails === 0) { peg$fail(peg$c210); }
           }
         }
       } else {
@@ -2590,22 +2641,22 @@ zlsa.atc.Parser = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c197.test(input.charAt(peg$currPos))) {
+      if (peg$c204.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c197.test(input.charAt(peg$currPos))) {
+          if (peg$c204.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c198); }
+            if (peg$silentFails === 0) { peg$fail(peg$c205); }
           }
         }
       } else {
@@ -2614,7 +2665,7 @@ zlsa.atc.Parser = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c204); }
+        if (peg$silentFails === 0) { peg$fail(peg$c211); }
       }
 
       return s0;
@@ -2627,33 +2678,33 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c163;
+        s3 = peg$c170;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c164); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c113.test(input.charAt(peg$currPos))) {
+        if (peg$c120.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c113.test(input.charAt(peg$currPos))) {
+            if (peg$c120.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c121); }
             }
           }
         } else {
@@ -2677,7 +2728,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c205(s1);
+        s1 = peg$c212(s1);
       }
       s0 = s1;
 

--- a/assets/scripts/parser.js
+++ b/assets/scripts/parser.js
@@ -109,8 +109,8 @@ zlsa.atc.Parser = (function() {
         peg$c70 = "log",
         peg$c71 = { type: "literal", value: "log", description: "\"log\"" },
         peg$c72 = function() {return ["debug"]},
-        peg$c73 = "descendviastart",
-        peg$c74 = { type: "literal", value: "descendviastart", description: "\"descendviastart\"" },
+        peg$c73 = "descendviastar",
+        peg$c74 = { type: "literal", value: "descendviastar", description: "\"descendviastar\"" },
         peg$c75 = "dvs",
         peg$c76 = { type: "literal", value: "dvs", description: "\"dvs\"" },
         peg$c77 = function() {return ["descendViaSTAR"]},
@@ -163,89 +163,90 @@ zlsa.atc.Parser = (function() {
                      dir,
                      length ? length[1] + length[2] : null,
                      fix ? fix[2] : null]},
-        peg$c124 = "land",
-        peg$c125 = { type: "literal", value: "land", description: "\"land\"" },
-        peg$c126 = "l",
-        peg$c127 = { type: "literal", value: "l", description: "\"l\"" },
-        peg$c128 = "ils",
-        peg$c129 = { type: "literal", value: "ils", description: "\"ils\"" },
-        peg$c130 = "i",
-        peg$c131 = { type: "literal", value: "i", description: "\"i\"" },
-        peg$c132 = function() {return "land"},
-        peg$c133 = /^[a-z]/i,
-        peg$c134 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
-        peg$c135 = function(cmd, variant, arg) {return [variant, arg]},
-        peg$c136 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
-        peg$c137 = "movedatablock",
-        peg$c138 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
-        peg$c139 = "`",
-        peg$c140 = { type: "literal", value: "`", description: "\"`\"" },
-        peg$c141 = function() {return "moveDataBlock"},
-        peg$c142 = /^[1-9]/,
-        peg$c143 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c144 = "route",
-        peg$c145 = { type: "literal", value: "route", description: "\"route\"" },
-        peg$c146 = function(arg) {return ["route", arg]},
-        peg$c147 = "reroute",
-        peg$c148 = { type: "literal", value: "reroute", description: "\"reroute\"" },
-        peg$c149 = "rr",
-        peg$c150 = { type: "literal", value: "rr", description: "\"rr\"" },
-        peg$c151 = function(arg) {return ["reroute", arg]},
-        peg$c152 = "sayroute",
-        peg$c153 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
-        peg$c154 = "sr",
-        peg$c155 = { type: "literal", value: "sr", description: "\"sr\"" },
-        peg$c156 = function() {return ["sayRoute"]},
-        peg$c157 = "sid",
-        peg$c158 = { type: "literal", value: "sid", description: "\"sid\"" },
-        peg$c159 = function(arg) {return ["sid", arg]},
-        peg$c160 = "+",
-        peg$c161 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c162 = "-",
-        peg$c163 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c164 = "speed",
-        peg$c165 = { type: "literal", value: "speed", description: "\"speed\"" },
-        peg$c166 = "slow",
-        peg$c167 = { type: "literal", value: "slow", description: "\"slow\"" },
-        peg$c168 = "sp",
-        peg$c169 = { type: "literal", value: "sp", description: "\"sp\"" },
-        peg$c170 = function() {return "speed"},
-        peg$c171 = "star",
-        peg$c172 = { type: "literal", value: "star", description: "\"star\"" },
-        peg$c173 = function(arg) {return ["star", arg]},
-        peg$c174 = "takeoff",
-        peg$c175 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
-        peg$c176 = "to",
-        peg$c177 = { type: "literal", value: "to", description: "\"to\"" },
-        peg$c178 = "cto",
-        peg$c179 = { type: "literal", value: "cto", description: "\"cto\"" },
-        peg$c180 = function() {return ["takeoff"]},
-        peg$c181 = "taxi",
-        peg$c182 = { type: "literal", value: "taxi", description: "\"taxi\"" },
-        peg$c183 = "wait",
-        peg$c184 = { type: "literal", value: "wait", description: "\"wait\"" },
-        peg$c185 = "w",
-        peg$c186 = { type: "literal", value: "w", description: "\"w\"" },
-        peg$c187 = function(runway) {return ["taxi", runway]},
-        peg$c188 = "left",
-        peg$c189 = { type: "literal", value: "left", description: "\"left\"" },
-        peg$c190 = "right",
-        peg$c191 = { type: "literal", value: "right", description: "\"right\"" },
-        peg$c192 = "r",
-        peg$c193 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c194 = function(dir) {return dir},
-        peg$c195 = function(fix) {return fix[2]},
-        peg$c196 = /^[ \t]/,
-        peg$c197 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
-        peg$c198 = ".",
-        peg$c199 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c200 = function() {
+        peg$c124 = function(cmd) {return [cmd[0], cmd[1], cmd[2]]},
+        peg$c125 = "land",
+        peg$c126 = { type: "literal", value: "land", description: "\"land\"" },
+        peg$c127 = "l",
+        peg$c128 = { type: "literal", value: "l", description: "\"l\"" },
+        peg$c129 = "ils",
+        peg$c130 = { type: "literal", value: "ils", description: "\"ils\"" },
+        peg$c131 = function() {return "land"},
+        peg$c132 = /^[a-z]/i,
+        peg$c133 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
+        peg$c134 = function(cmd, variant, arg) {return [variant, arg]},
+        peg$c135 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
+        peg$c136 = "\u2B50",
+        peg$c137 = { type: "literal", value: "\u2B50", description: "\"\\u2B50\"" },
+        peg$c138 = "movedatablock",
+        peg$c139 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
+        peg$c140 = "`",
+        peg$c141 = { type: "literal", value: "`", description: "\"`\"" },
+        peg$c142 = function() {return "moveDataBlock"},
+        peg$c143 = /^[1-9]/,
+        peg$c144 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c145 = "route",
+        peg$c146 = { type: "literal", value: "route", description: "\"route\"" },
+        peg$c147 = function(arg) {return ["route", arg]},
+        peg$c148 = "reroute",
+        peg$c149 = { type: "literal", value: "reroute", description: "\"reroute\"" },
+        peg$c150 = "rr",
+        peg$c151 = { type: "literal", value: "rr", description: "\"rr\"" },
+        peg$c152 = function(arg) {return ["reroute", arg]},
+        peg$c153 = "sayroute",
+        peg$c154 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
+        peg$c155 = "sr",
+        peg$c156 = { type: "literal", value: "sr", description: "\"sr\"" },
+        peg$c157 = function() {return ["sayRoute"]},
+        peg$c158 = "sid",
+        peg$c159 = { type: "literal", value: "sid", description: "\"sid\"" },
+        peg$c160 = function(arg) {return ["sid", arg]},
+        peg$c161 = "+",
+        peg$c162 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c163 = "-",
+        peg$c164 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c165 = "speed",
+        peg$c166 = { type: "literal", value: "speed", description: "\"speed\"" },
+        peg$c167 = "slow",
+        peg$c168 = { type: "literal", value: "slow", description: "\"slow\"" },
+        peg$c169 = "sp",
+        peg$c170 = { type: "literal", value: "sp", description: "\"sp\"" },
+        peg$c171 = function() {return "speed"},
+        peg$c172 = "star",
+        peg$c173 = { type: "literal", value: "star", description: "\"star\"" },
+        peg$c174 = function(arg) {return ["star", arg]},
+        peg$c175 = "takeoff",
+        peg$c176 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
+        peg$c177 = "to",
+        peg$c178 = { type: "literal", value: "to", description: "\"to\"" },
+        peg$c179 = "cto",
+        peg$c180 = { type: "literal", value: "cto", description: "\"cto\"" },
+        peg$c181 = function() {return ["takeoff"]},
+        peg$c182 = "taxi",
+        peg$c183 = { type: "literal", value: "taxi", description: "\"taxi\"" },
+        peg$c184 = "wait",
+        peg$c185 = { type: "literal", value: "wait", description: "\"wait\"" },
+        peg$c186 = "w",
+        peg$c187 = { type: "literal", value: "w", description: "\"w\"" },
+        peg$c188 = function(runway) {return ["taxi", runway]},
+        peg$c189 = "left",
+        peg$c190 = { type: "literal", value: "left", description: "\"left\"" },
+        peg$c191 = "right",
+        peg$c192 = { type: "literal", value: "right", description: "\"right\"" },
+        peg$c193 = "r",
+        peg$c194 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c195 = function(dir) {return dir},
+        peg$c196 = function(fix) {return fix[2]},
+        peg$c197 = /^[ \t]/,
+        peg$c198 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
+        peg$c199 = ".",
+        peg$c200 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c201 = function() {
             return parseFloat(text());
           },
-        peg$c201 = /^[a-zA-Z0-9.]/,
-        peg$c202 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
-        peg$c203 = { type: "other", description: "whiteSpace" },
-        peg$c204 = function(arg) {return parseInt(arg)},
+        peg$c202 = /^[a-zA-Z0-9.]/,
+        peg$c203 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
+        peg$c204 = { type: "other", description: "whiteSpace" },
+        peg$c205 = function(arg) {return parseInt(arg)},
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -1206,9 +1207,9 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 15) === peg$c73) {
+      if (input.substr(peg$currPos, 14) === peg$c73) {
         s1 = peg$c73;
-        peg$currPos += 15;
+        peg$currPos += 14;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c74); }
@@ -1703,59 +1704,67 @@ zlsa.atc.Parser = (function() {
     }
 
     function peg$parsecmdLand() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      s1 = peg$parsecmdLandShort();
+      if (s1 === peg$FAILED) {
+        s1 = peg$parsecmdLandLong();
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c124(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsecmdLandLong() {
       var s0, s1, s2, s3, s4, s5;
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c124) {
-        s2 = peg$c124;
+      if (input.substr(peg$currPos, 4) === peg$c125) {
+        s2 = peg$c125;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+        if (peg$silentFails === 0) { peg$fail(peg$c126); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 108) {
-          s2 = peg$c126;
+          s2 = peg$c127;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+          if (peg$silentFails === 0) { peg$fail(peg$c128); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c128) {
-            s2 = peg$c128;
+          if (input.substr(peg$currPos, 3) === peg$c129) {
+            s2 = peg$c129;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
-          }
-          if (s2 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 105) {
-              s2 = peg$c130;
-              peg$currPos++;
-            } else {
-              s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c131); }
-            }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c132();
+        s2 = peg$c131();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = peg$parsewhiteSpace();
         if (s3 !== peg$FAILED) {
-          if (peg$c133.test(input.charAt(peg$currPos))) {
+          if (peg$c132.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c134); }
+            if (peg$silentFails === 0) { peg$fail(peg$c133); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -1764,7 +1773,7 @@ zlsa.atc.Parser = (function() {
             s5 = peg$parsestring();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c135(s1, s4, s5);
+              s3 = peg$c134(s1, s4, s5);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1780,7 +1789,66 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1, s2);
+          s1 = peg$c135(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsecmdLandShort() {
+      var s0, s1, s2, s3, s4;
+
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 11088) {
+        s2 = peg$c136;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s1;
+        s2 = peg$c131();
+      }
+      s1 = s2;
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        if (peg$c132.test(input.charAt(peg$currPos))) {
+          s3 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        }
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsestring();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s2;
+            s3 = peg$c134(s1, s3, s4);
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c135(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1800,12 +1868,12 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       s2 = peg$currPos;
-      if (input.substr(peg$currPos, 13) === peg$c137) {
-        s3 = peg$c137;
+      if (input.substr(peg$currPos, 13) === peg$c138) {
+        s3 = peg$c138;
         peg$currPos += 13;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+        if (peg$silentFails === 0) { peg$fail(peg$c139); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsewhiteSpace();
@@ -1822,25 +1890,25 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 96) {
-          s2 = peg$c139;
+          s2 = peg$c140;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c140); }
+          if (peg$silentFails === 0) { peg$fail(peg$c141); }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c141();
+        s2 = peg$c142();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
-        if (peg$c142.test(input.charAt(peg$currPos))) {
+        if (peg$c143.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -1861,12 +1929,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c144) {
-        s1 = peg$c144;
+      if (input.substr(peg$currPos, 5) === peg$c145) {
+        s1 = peg$c145;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c145); }
+        if (peg$silentFails === 0) { peg$fail(peg$c146); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1874,7 +1942,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c146(s3);
+            s1 = peg$c147(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1896,20 +1964,20 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c147) {
-        s1 = peg$c147;
+      if (input.substr(peg$currPos, 7) === peg$c148) {
+        s1 = peg$c148;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c149) {
-          s1 = peg$c149;
+        if (input.substr(peg$currPos, 2) === peg$c150) {
+          s1 = peg$c150;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c150); }
+          if (peg$silentFails === 0) { peg$fail(peg$c151); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -1918,7 +1986,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c151(s3);
+            s1 = peg$c152(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1940,25 +2008,25 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 8) === peg$c153) {
+        s1 = peg$c153;
         peg$currPos += 8;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c154) {
-          s1 = peg$c154;
+        if (input.substr(peg$currPos, 2) === peg$c155) {
+          s1 = peg$c155;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c156); }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c156();
+        s1 = peg$c157();
       }
       s0 = s1;
 
@@ -1969,12 +2037,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c157) {
-        s1 = peg$c157;
+      if (input.substr(peg$currPos, 3) === peg$c158) {
+        s1 = peg$c158;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c158); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1982,7 +2050,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c159(s3);
+            s1 = peg$c160(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2006,45 +2074,45 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s2 = peg$c160;
+        s2 = peg$c161;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c162); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s2 = peg$c162;
+          s2 = peg$c163;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c164); }
         }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 5) === peg$c164) {
-          s3 = peg$c164;
+        if (input.substr(peg$currPos, 5) === peg$c165) {
+          s3 = peg$c165;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c165); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
         if (s3 === peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c166) {
-            s3 = peg$c166;
+          if (input.substr(peg$currPos, 4) === peg$c167) {
+            s3 = peg$c167;
             peg$currPos += 4;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c167); }
+            if (peg$silentFails === 0) { peg$fail(peg$c168); }
           }
           if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c168) {
-              s3 = peg$c168;
+            if (input.substr(peg$currPos, 2) === peg$c169) {
+              s3 = peg$c169;
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c169); }
+              if (peg$silentFails === 0) { peg$fail(peg$c170); }
             }
           }
         }
@@ -2064,7 +2132,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c170();
+        s2 = peg$c171();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -2088,12 +2156,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c171) {
-        s1 = peg$c171;
+      if (input.substr(peg$currPos, 4) === peg$c172) {
+        s1 = peg$c172;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
+        if (peg$silentFails === 0) { peg$fail(peg$c173); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2101,7 +2169,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s3);
+            s1 = peg$c174(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2123,34 +2191,34 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c174) {
-        s1 = peg$c174;
+      if (input.substr(peg$currPos, 7) === peg$c175) {
+        s1 = peg$c175;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c176); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c176) {
-          s1 = peg$c176;
+        if (input.substr(peg$currPos, 2) === peg$c177) {
+          s1 = peg$c177;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c177); }
+          if (peg$silentFails === 0) { peg$fail(peg$c178); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c178) {
-            s1 = peg$c178;
+          if (input.substr(peg$currPos, 3) === peg$c179) {
+            s1 = peg$c179;
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c179); }
+            if (peg$silentFails === 0) { peg$fail(peg$c180); }
           }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c180();
+        s1 = peg$c181();
       }
       s0 = s1;
 
@@ -2161,28 +2229,28 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c181) {
-        s1 = peg$c181;
+      if (input.substr(peg$currPos, 4) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c183) {
-          s1 = peg$c183;
+        if (input.substr(peg$currPos, 4) === peg$c184) {
+          s1 = peg$c184;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 119) {
-            s1 = peg$c185;
+            s1 = peg$c186;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+            if (peg$silentFails === 0) { peg$fail(peg$c187); }
           }
         }
       }
@@ -2208,7 +2276,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c187(s2);
+          s1 = peg$c188(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2229,20 +2297,20 @@ zlsa.atc.Parser = (function() {
       s1 = peg$parsewhiteSpace();
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c188) {
-          s3 = peg$c188;
+        if (input.substr(peg$currPos, 4) === peg$c189) {
+          s3 = peg$c189;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 108) {
-            s3 = peg$c126;
+            s3 = peg$c127;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            if (peg$silentFails === 0) { peg$fail(peg$c128); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -2252,20 +2320,20 @@ zlsa.atc.Parser = (function() {
         s2 = s3;
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c190) {
-            s3 = peg$c190;
+          if (input.substr(peg$currPos, 5) === peg$c191) {
+            s3 = peg$c191;
             peg$currPos += 5;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c191); }
+            if (peg$silentFails === 0) { peg$fail(peg$c192); }
           }
           if (s3 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 114) {
-              s3 = peg$c192;
+              s3 = peg$c193;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c193); }
+              if (peg$silentFails === 0) { peg$fail(peg$c194); }
             }
           }
           if (s3 !== peg$FAILED) {
@@ -2276,7 +2344,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c194(s2);
+          s1 = peg$c195(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2326,7 +2394,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1);
+        s1 = peg$c196(s1);
       }
       s0 = s1;
 
@@ -2338,22 +2406,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c196.test(input.charAt(peg$currPos))) {
+      if (peg$c197.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c197); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c196.test(input.charAt(peg$currPos))) {
+          if (peg$c197.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c197); }
+            if (peg$silentFails === 0) { peg$fail(peg$c198); }
           }
         }
       } else {
@@ -2375,11 +2443,11 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c162;
+        s3 = peg$c163;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
@@ -2410,11 +2478,11 @@ zlsa.atc.Parser = (function() {
         if (s4 !== peg$FAILED) {
           s5 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s6 = peg$c198;
+            s6 = peg$c199;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+            if (peg$silentFails === 0) { peg$fail(peg$c200); }
           }
           if (s6 !== peg$FAILED) {
             s7 = [];
@@ -2475,7 +2543,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c200();
+        s1 = peg$c201();
       }
       s0 = s1;
 
@@ -2487,22 +2555,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c201.test(input.charAt(peg$currPos))) {
+      if (peg$c202.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+        if (peg$silentFails === 0) { peg$fail(peg$c203); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c201.test(input.charAt(peg$currPos))) {
+          if (peg$c202.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+            if (peg$silentFails === 0) { peg$fail(peg$c203); }
           }
         }
       } else {
@@ -2522,22 +2590,22 @@ zlsa.atc.Parser = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c196.test(input.charAt(peg$currPos))) {
+      if (peg$c197.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c197); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c196.test(input.charAt(peg$currPos))) {
+          if (peg$c197.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c197); }
+            if (peg$silentFails === 0) { peg$fail(peg$c198); }
           }
         }
       } else {
@@ -2546,7 +2614,7 @@ zlsa.atc.Parser = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c203); }
+        if (peg$silentFails === 0) { peg$fail(peg$c204); }
       }
 
       return s0;
@@ -2559,11 +2627,11 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c162;
+        s3 = peg$c163;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
@@ -2609,7 +2677,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c204(s1);
+        s1 = peg$c205(s1);
       }
       s0 = s1;
 

--- a/assets/scripts/parser.js
+++ b/assets/scripts/parser.js
@@ -135,125 +135,128 @@ zlsa.atc.Parser = (function() {
         peg$c96 = "track",
         peg$c97 = { type: "literal", value: "track", description: "\"track\"" },
         peg$c98 = function() {return "fix"},
-        peg$c99 = function(cmd) { return [cmd[0], cmd[1], cmd[2][0], cmd[2][1]] },
-        peg$c100 = "\u2BA2",
-        peg$c101 = { type: "literal", value: "\u2BA2", description: "\"\\u2BA2\"" },
-        peg$c102 = function() {return "left"},
-        peg$c103 = "\u2BA3",
-        peg$c104 = { type: "literal", value: "\u2BA3", description: "\"\\u2BA3\"" },
-        peg$c105 = function() {return "right"},
-        peg$c106 = "fh",
-        peg$c107 = { type: "literal", value: "fh", description: "\"fh\"" },
-        peg$c108 = function() {return null},
-        peg$c109 = function(dir, arg) {return ['heading', dir, arg]},
-        peg$c110 = "heading",
-        peg$c111 = { type: "literal", value: "heading", description: "\"heading\"" },
-        peg$c112 = "turn",
-        peg$c113 = { type: "literal", value: "turn", description: "\"turn\"" },
-        peg$c114 = "t",
-        peg$c115 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c116 = "h",
-        peg$c117 = { type: "literal", value: "h", description: "\"h\"" },
-        peg$c118 = function() {return "heading"},
-        peg$c119 = function(arg) {return arg},
-        peg$c120 = /^[0-9]/,
-        peg$c121 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c122 = function() {return [parseInt(text()), false]},
-        peg$c123 = function() {return [parseInt(text()), true]},
-        peg$c124 = "hold",
-        peg$c125 = { type: "literal", value: "hold", description: "\"hold\"" },
-        peg$c126 = "min",
-        peg$c127 = { type: "literal", value: "min", description: "\"min\"" },
-        peg$c128 = "nm",
-        peg$c129 = { type: "literal", value: "nm", description: "\"nm\"" },
-        peg$c130 = function(dir, length, fix) {return ["hold",
+        peg$c99 = "fph",
+        peg$c100 = { type: "literal", value: "fph", description: "\"fph\"" },
+        peg$c101 = function() {return ['flyPresentHeading']},
+        peg$c102 = function(cmd) { return [cmd[0], cmd[1], cmd[2][0], cmd[2][1]] },
+        peg$c103 = "\u2BA2",
+        peg$c104 = { type: "literal", value: "\u2BA2", description: "\"\\u2BA2\"" },
+        peg$c105 = function() {return "left"},
+        peg$c106 = "\u2BA3",
+        peg$c107 = { type: "literal", value: "\u2BA3", description: "\"\\u2BA3\"" },
+        peg$c108 = function() {return "right"},
+        peg$c109 = "fh",
+        peg$c110 = { type: "literal", value: "fh", description: "\"fh\"" },
+        peg$c111 = function() {return null},
+        peg$c112 = function(dir, arg) {return ['heading', dir, arg]},
+        peg$c113 = "heading",
+        peg$c114 = { type: "literal", value: "heading", description: "\"heading\"" },
+        peg$c115 = "turn",
+        peg$c116 = { type: "literal", value: "turn", description: "\"turn\"" },
+        peg$c117 = "t",
+        peg$c118 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c119 = "h",
+        peg$c120 = { type: "literal", value: "h", description: "\"h\"" },
+        peg$c121 = function() {return "heading"},
+        peg$c122 = function(arg) {return arg},
+        peg$c123 = /^[0-9]/,
+        peg$c124 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c125 = function() {return [parseInt(text()), false]},
+        peg$c126 = function() {return [parseInt(text()), true]},
+        peg$c127 = "hold",
+        peg$c128 = { type: "literal", value: "hold", description: "\"hold\"" },
+        peg$c129 = "min",
+        peg$c130 = { type: "literal", value: "min", description: "\"min\"" },
+        peg$c131 = "nm",
+        peg$c132 = { type: "literal", value: "nm", description: "\"nm\"" },
+        peg$c133 = function(dir, length, fix) {return ["hold",
                      dir,
                      length ? length[1] + length[2] : null,
                      fix ? fix[2] : null]},
-        peg$c131 = function(cmd) {return [cmd[0], cmd[1], cmd[2]]},
-        peg$c132 = "land",
-        peg$c133 = { type: "literal", value: "land", description: "\"land\"" },
-        peg$c134 = "l",
-        peg$c135 = { type: "literal", value: "l", description: "\"l\"" },
-        peg$c136 = "ils",
-        peg$c137 = { type: "literal", value: "ils", description: "\"ils\"" },
-        peg$c138 = function() {return "land"},
-        peg$c139 = /^[a-z]/i,
-        peg$c140 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
-        peg$c141 = function(cmd, variant, arg) {return [variant, arg]},
-        peg$c142 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
-        peg$c143 = "\u2B50",
-        peg$c144 = { type: "literal", value: "\u2B50", description: "\"\\u2B50\"" },
-        peg$c145 = "movedatablock",
-        peg$c146 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
-        peg$c147 = "`",
-        peg$c148 = { type: "literal", value: "`", description: "\"`\"" },
-        peg$c149 = function() {return "moveDataBlock"},
-        peg$c150 = /^[1-9]/,
-        peg$c151 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c152 = "route",
-        peg$c153 = { type: "literal", value: "route", description: "\"route\"" },
-        peg$c154 = function(arg) {return ["route", arg]},
-        peg$c155 = "reroute",
-        peg$c156 = { type: "literal", value: "reroute", description: "\"reroute\"" },
-        peg$c157 = "rr",
-        peg$c158 = { type: "literal", value: "rr", description: "\"rr\"" },
-        peg$c159 = function(arg) {return ["reroute", arg]},
-        peg$c160 = "sayroute",
-        peg$c161 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
-        peg$c162 = "sr",
-        peg$c163 = { type: "literal", value: "sr", description: "\"sr\"" },
-        peg$c164 = function() {return ["sayRoute"]},
-        peg$c165 = "sid",
-        peg$c166 = { type: "literal", value: "sid", description: "\"sid\"" },
-        peg$c167 = function(arg) {return ["sid", arg]},
-        peg$c168 = "+",
-        peg$c169 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c170 = "-",
-        peg$c171 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c172 = "speed",
-        peg$c173 = { type: "literal", value: "speed", description: "\"speed\"" },
-        peg$c174 = "slow",
-        peg$c175 = { type: "literal", value: "slow", description: "\"slow\"" },
-        peg$c176 = "sp",
-        peg$c177 = { type: "literal", value: "sp", description: "\"sp\"" },
-        peg$c178 = function() {return "speed"},
-        peg$c179 = "star",
-        peg$c180 = { type: "literal", value: "star", description: "\"star\"" },
-        peg$c181 = function(arg) {return ["star", arg]},
-        peg$c182 = "takeoff",
-        peg$c183 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
-        peg$c184 = "to",
-        peg$c185 = { type: "literal", value: "to", description: "\"to\"" },
-        peg$c186 = "cto",
-        peg$c187 = { type: "literal", value: "cto", description: "\"cto\"" },
-        peg$c188 = function() {return ["takeoff"]},
-        peg$c189 = "taxi",
-        peg$c190 = { type: "literal", value: "taxi", description: "\"taxi\"" },
-        peg$c191 = "wait",
-        peg$c192 = { type: "literal", value: "wait", description: "\"wait\"" },
-        peg$c193 = "w",
-        peg$c194 = { type: "literal", value: "w", description: "\"w\"" },
-        peg$c195 = function(runway) {return ["taxi", runway]},
-        peg$c196 = "left",
-        peg$c197 = { type: "literal", value: "left", description: "\"left\"" },
-        peg$c198 = "right",
-        peg$c199 = { type: "literal", value: "right", description: "\"right\"" },
-        peg$c200 = "r",
-        peg$c201 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c202 = function(dir) {return dir},
-        peg$c203 = function(fix) {return fix[2]},
-        peg$c204 = /^[ \t]/,
-        peg$c205 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
-        peg$c206 = ".",
-        peg$c207 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c208 = function() {
+        peg$c134 = function(cmd) {return [cmd[0], cmd[1], cmd[2]]},
+        peg$c135 = "land",
+        peg$c136 = { type: "literal", value: "land", description: "\"land\"" },
+        peg$c137 = "l",
+        peg$c138 = { type: "literal", value: "l", description: "\"l\"" },
+        peg$c139 = "ils",
+        peg$c140 = { type: "literal", value: "ils", description: "\"ils\"" },
+        peg$c141 = function() {return "land"},
+        peg$c142 = /^[a-z]/i,
+        peg$c143 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
+        peg$c144 = function(cmd, variant, arg) {return [variant, arg]},
+        peg$c145 = function(cmd, arg) { return [cmd, arg[0], arg[1]] },
+        peg$c146 = "\u2B50",
+        peg$c147 = { type: "literal", value: "\u2B50", description: "\"\\u2B50\"" },
+        peg$c148 = "movedatablock",
+        peg$c149 = { type: "literal", value: "movedatablock", description: "\"movedatablock\"" },
+        peg$c150 = "`",
+        peg$c151 = { type: "literal", value: "`", description: "\"`\"" },
+        peg$c152 = function() {return "moveDataBlock"},
+        peg$c153 = /^[1-9]/,
+        peg$c154 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c155 = "route",
+        peg$c156 = { type: "literal", value: "route", description: "\"route\"" },
+        peg$c157 = function(arg) {return ["route", arg]},
+        peg$c158 = "reroute",
+        peg$c159 = { type: "literal", value: "reroute", description: "\"reroute\"" },
+        peg$c160 = "rr",
+        peg$c161 = { type: "literal", value: "rr", description: "\"rr\"" },
+        peg$c162 = function(arg) {return ["reroute", arg]},
+        peg$c163 = "sayroute",
+        peg$c164 = { type: "literal", value: "sayroute", description: "\"sayroute\"" },
+        peg$c165 = "sr",
+        peg$c166 = { type: "literal", value: "sr", description: "\"sr\"" },
+        peg$c167 = function() {return ["sayRoute"]},
+        peg$c168 = "sid",
+        peg$c169 = { type: "literal", value: "sid", description: "\"sid\"" },
+        peg$c170 = function(arg) {return ["sid", arg]},
+        peg$c171 = "+",
+        peg$c172 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c173 = "-",
+        peg$c174 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c175 = "speed",
+        peg$c176 = { type: "literal", value: "speed", description: "\"speed\"" },
+        peg$c177 = "slow",
+        peg$c178 = { type: "literal", value: "slow", description: "\"slow\"" },
+        peg$c179 = "sp",
+        peg$c180 = { type: "literal", value: "sp", description: "\"sp\"" },
+        peg$c181 = function() {return "speed"},
+        peg$c182 = "star",
+        peg$c183 = { type: "literal", value: "star", description: "\"star\"" },
+        peg$c184 = function(arg) {return ["star", arg]},
+        peg$c185 = "takeoff",
+        peg$c186 = { type: "literal", value: "takeoff", description: "\"takeoff\"" },
+        peg$c187 = "to",
+        peg$c188 = { type: "literal", value: "to", description: "\"to\"" },
+        peg$c189 = "cto",
+        peg$c190 = { type: "literal", value: "cto", description: "\"cto\"" },
+        peg$c191 = function() {return ["takeoff"]},
+        peg$c192 = "taxi",
+        peg$c193 = { type: "literal", value: "taxi", description: "\"taxi\"" },
+        peg$c194 = "wait",
+        peg$c195 = { type: "literal", value: "wait", description: "\"wait\"" },
+        peg$c196 = "w",
+        peg$c197 = { type: "literal", value: "w", description: "\"w\"" },
+        peg$c198 = function(runway) {return ["taxi", runway]},
+        peg$c199 = "left",
+        peg$c200 = { type: "literal", value: "left", description: "\"left\"" },
+        peg$c201 = "right",
+        peg$c202 = { type: "literal", value: "right", description: "\"right\"" },
+        peg$c203 = "r",
+        peg$c204 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c205 = function(dir) {return dir},
+        peg$c206 = function(fix) {return fix[2]},
+        peg$c207 = /^[ \t]/,
+        peg$c208 = { type: "class", value: "[ \\t]", description: "[ \\t]" },
+        peg$c209 = ".",
+        peg$c210 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c211 = function() {
             return parseFloat(text());
           },
-        peg$c209 = /^[a-zA-Z0-9.]/,
-        peg$c210 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
-        peg$c211 = { type: "other", description: "whiteSpace" },
-        peg$c212 = function(arg) {return parseInt(arg)},
+        peg$c212 = /^[a-zA-Z0-9.]/,
+        peg$c213 = { type: "class", value: "[a-zA-Z0-9.]", description: "[a-zA-Z0-9.]" },
+        peg$c214 = { type: "other", description: "whiteSpace" },
+        peg$c215 = function(arg) {return parseInt(arg)},
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -763,29 +766,32 @@ zlsa.atc.Parser = (function() {
                       if (s3 === peg$FAILED) {
                         s3 = peg$parsecmdFix();
                         if (s3 === peg$FAILED) {
-                          s3 = peg$parsecmdHeading();
+                          s3 = peg$parsecmdFlyPresentHeading();
                           if (s3 === peg$FAILED) {
-                            s3 = peg$parsecmdHold();
+                            s3 = peg$parsecmdHeading();
                             if (s3 === peg$FAILED) {
-                              s3 = peg$parsecmdLand();
+                              s3 = peg$parsecmdHold();
                               if (s3 === peg$FAILED) {
-                                s3 = peg$parsecmdMoveDataBlock();
+                                s3 = peg$parsecmdLand();
                                 if (s3 === peg$FAILED) {
-                                  s3 = peg$parsecmdRoute();
+                                  s3 = peg$parsecmdMoveDataBlock();
                                   if (s3 === peg$FAILED) {
-                                    s3 = peg$parsecmdReRoute();
+                                    s3 = peg$parsecmdRoute();
                                     if (s3 === peg$FAILED) {
-                                      s3 = peg$parsecmdSayRoute();
+                                      s3 = peg$parsecmdReRoute();
                                       if (s3 === peg$FAILED) {
-                                        s3 = peg$parsecmdSID();
+                                        s3 = peg$parsecmdSayRoute();
                                         if (s3 === peg$FAILED) {
-                                          s3 = peg$parsecmdSpeed();
+                                          s3 = peg$parsecmdSID();
                                           if (s3 === peg$FAILED) {
-                                            s3 = peg$parsecmdSTAR();
+                                            s3 = peg$parsecmdSpeed();
                                             if (s3 === peg$FAILED) {
-                                              s3 = peg$parsecmdTakeoff();
+                                              s3 = peg$parsecmdSTAR();
                                               if (s3 === peg$FAILED) {
-                                                s3 = peg$parsecmdTaxi();
+                                                s3 = peg$parsecmdTakeoff();
+                                                if (s3 === peg$FAILED) {
+                                                  s3 = peg$parsecmdTaxi();
+                                                }
                                               }
                                             }
                                           }
@@ -842,29 +848,32 @@ zlsa.atc.Parser = (function() {
                           if (s3 === peg$FAILED) {
                             s3 = peg$parsecmdFix();
                             if (s3 === peg$FAILED) {
-                              s3 = peg$parsecmdHeading();
+                              s3 = peg$parsecmdFlyPresentHeading();
                               if (s3 === peg$FAILED) {
-                                s3 = peg$parsecmdHold();
+                                s3 = peg$parsecmdHeading();
                                 if (s3 === peg$FAILED) {
-                                  s3 = peg$parsecmdLand();
+                                  s3 = peg$parsecmdHold();
                                   if (s3 === peg$FAILED) {
-                                    s3 = peg$parsecmdMoveDataBlock();
+                                    s3 = peg$parsecmdLand();
                                     if (s3 === peg$FAILED) {
-                                      s3 = peg$parsecmdRoute();
+                                      s3 = peg$parsecmdMoveDataBlock();
                                       if (s3 === peg$FAILED) {
-                                        s3 = peg$parsecmdReRoute();
+                                        s3 = peg$parsecmdRoute();
                                         if (s3 === peg$FAILED) {
-                                          s3 = peg$parsecmdSayRoute();
+                                          s3 = peg$parsecmdReRoute();
                                           if (s3 === peg$FAILED) {
-                                            s3 = peg$parsecmdSID();
+                                            s3 = peg$parsecmdSayRoute();
                                             if (s3 === peg$FAILED) {
-                                              s3 = peg$parsecmdSpeed();
+                                              s3 = peg$parsecmdSID();
                                               if (s3 === peg$FAILED) {
-                                                s3 = peg$parsecmdSTAR();
+                                                s3 = peg$parsecmdSpeed();
                                                 if (s3 === peg$FAILED) {
-                                                  s3 = peg$parsecmdTakeoff();
+                                                  s3 = peg$parsecmdSTAR();
                                                   if (s3 === peg$FAILED) {
-                                                    s3 = peg$parsecmdTaxi();
+                                                    s3 = peg$parsecmdTakeoff();
+                                                    if (s3 === peg$FAILED) {
+                                                      s3 = peg$parsecmdTaxi();
+                                                    }
                                                   }
                                                 }
                                               }
@@ -1396,6 +1405,26 @@ zlsa.atc.Parser = (function() {
       return s0;
     }
 
+    function peg$parsecmdFlyPresentHeading() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 3) === peg$c99) {
+        s1 = peg$c99;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c101();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
     function peg$parsecmdHeading() {
       var s0, s1;
 
@@ -1406,7 +1435,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99(s1);
+        s1 = peg$c102(s1);
       }
       s0 = s1;
 
@@ -1419,43 +1448,43 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 11170) {
-        s2 = peg$c100;
+        s2 = peg$c103;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        if (peg$silentFails === 0) { peg$fail(peg$c104); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c102();
+        s2 = peg$c105();
       }
       s1 = s2;
       if (s1 === peg$FAILED) {
         s1 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 11171) {
-          s2 = peg$c103;
+          s2 = peg$c106;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c104); }
+          if (peg$silentFails === 0) { peg$fail(peg$c107); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c105();
+          s2 = peg$c108();
         }
         s1 = s2;
         if (s1 === peg$FAILED) {
           s1 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c106) {
-            s2 = peg$c106;
+          if (input.substr(peg$currPos, 2) === peg$c109) {
+            s2 = peg$c109;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s1;
-            s2 = peg$c108();
+            s2 = peg$c111();
           }
           s1 = s2;
         }
@@ -1464,7 +1493,7 @@ zlsa.atc.Parser = (function() {
         s2 = peg$parseargHeading();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c109(s1, s2);
+          s1 = peg$c112(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1483,43 +1512,43 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c110) {
-        s2 = peg$c110;
+      if (input.substr(peg$currPos, 7) === peg$c113) {
+        s2 = peg$c113;
         peg$currPos += 7;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c112) {
-          s2 = peg$c112;
+        if (input.substr(peg$currPos, 4) === peg$c115) {
+          s2 = peg$c115;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c113); }
+          if (peg$silentFails === 0) { peg$fail(peg$c116); }
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 116) {
-            s2 = peg$c114;
+            s2 = peg$c117;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c115); }
+            if (peg$silentFails === 0) { peg$fail(peg$c118); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 104) {
-              s2 = peg$c116;
+              s2 = peg$c119;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c117); }
+              if (peg$silentFails === 0) { peg$fail(peg$c120); }
             }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c118();
+        s2 = peg$c121();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -1534,7 +1563,7 @@ zlsa.atc.Parser = (function() {
             s5 = peg$parseargHeading();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c119(s5);
+              s4 = peg$c122(s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -1567,32 +1596,32 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (peg$c120.test(input.charAt(peg$currPos))) {
+      if (peg$c123.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c124); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c120.test(input.charAt(peg$currPos))) {
+        if (peg$c123.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c124); }
         }
         if (s2 !== peg$FAILED) {
-          if (peg$c120.test(input.charAt(peg$currPos))) {
+          if (peg$c123.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c124); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c122();
+            s1 = peg$c125();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1608,24 +1637,24 @@ zlsa.atc.Parser = (function() {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c120.test(input.charAt(peg$currPos))) {
+        if (peg$c123.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c124); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c120.test(input.charAt(peg$currPos))) {
+          if (peg$c123.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c124); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c123();
+            s1 = peg$c126();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1644,12 +1673,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c124) {
-        s1 = peg$c124;
+      if (input.substr(peg$currPos, 4) === peg$c127) {
+        s1 = peg$c127;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+        if (peg$silentFails === 0) { peg$fail(peg$c128); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedirection();
@@ -1662,20 +1691,20 @@ zlsa.atc.Parser = (function() {
           if (s4 !== peg$FAILED) {
             s5 = peg$parseinteger();
             if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c126) {
-                s6 = peg$c126;
+              if (input.substr(peg$currPos, 3) === peg$c129) {
+                s6 = peg$c129;
                 peg$currPos += 3;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                if (peg$silentFails === 0) { peg$fail(peg$c130); }
               }
               if (s6 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c128) {
-                  s6 = peg$c128;
+                if (input.substr(peg$currPos, 2) === peg$c131) {
+                  s6 = peg$c131;
                   peg$currPos += 2;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c129); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c132); }
                 }
               }
               if (s6 !== peg$FAILED) {
@@ -1732,7 +1761,7 @@ zlsa.atc.Parser = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c130(s2, s3, s4);
+              s1 = peg$c133(s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1764,7 +1793,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c131(s1);
+        s1 = peg$c134(s1);
       }
       s0 = s1;
 
@@ -1776,46 +1805,46 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c132) {
-        s2 = peg$c132;
+      if (input.substr(peg$currPos, 4) === peg$c135) {
+        s2 = peg$c135;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c136); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 108) {
-          s2 = peg$c134;
+          s2 = peg$c137;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c135); }
+          if (peg$silentFails === 0) { peg$fail(peg$c138); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c136) {
-            s2 = peg$c136;
+          if (input.substr(peg$currPos, 3) === peg$c139) {
+            s2 = peg$c139;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c137); }
+            if (peg$silentFails === 0) { peg$fail(peg$c140); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c138();
+        s2 = peg$c141();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = peg$parsewhiteSpace();
         if (s3 !== peg$FAILED) {
-          if (peg$c139.test(input.charAt(peg$currPos))) {
+          if (peg$c142.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c140); }
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -1824,7 +1853,7 @@ zlsa.atc.Parser = (function() {
             s5 = peg$parsestring();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c141(s1, s4, s5);
+              s3 = peg$c144(s1, s4, s5);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1840,7 +1869,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s1, s2);
+          s1 = peg$c145(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1860,25 +1889,25 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 11088) {
-        s2 = peg$c143;
+        s2 = peg$c146;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c138();
+        s2 = peg$c141();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c139.test(input.charAt(peg$currPos))) {
+        if (peg$c142.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c140); }
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
         }
         if (s3 === peg$FAILED) {
           s3 = null;
@@ -1887,7 +1916,7 @@ zlsa.atc.Parser = (function() {
           s4 = peg$parsestring();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c141(s1, s3, s4);
+            s3 = peg$c144(s1, s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1899,7 +1928,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s1, s2);
+          s1 = peg$c145(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1919,12 +1948,12 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       s2 = peg$currPos;
-      if (input.substr(peg$currPos, 13) === peg$c145) {
-        s3 = peg$c145;
+      if (input.substr(peg$currPos, 13) === peg$c148) {
+        s3 = peg$c148;
         peg$currPos += 13;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c146); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsewhiteSpace();
@@ -1941,25 +1970,25 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 96) {
-          s2 = peg$c147;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c148); }
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s1;
-        s2 = peg$c149();
-      }
-      s1 = s2;
-      if (s1 !== peg$FAILED) {
-        if (peg$c150.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
+          s2 = peg$c150;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s1;
+        s2 = peg$c152();
+      }
+      s1 = s2;
+      if (s1 !== peg$FAILED) {
+        if (peg$c153.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c154); }
         }
         if (s2 !== peg$FAILED) {
           s1 = [s1, s2];
@@ -1980,12 +2009,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 5) === peg$c155) {
+        s1 = peg$c155;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -1993,7 +2022,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c154(s3);
+            s1 = peg$c157(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2015,20 +2044,20 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c155) {
-        s1 = peg$c155;
+      if (input.substr(peg$currPos, 7) === peg$c158) {
+        s1 = peg$c158;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c156); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c157) {
-          s1 = peg$c157;
+        if (input.substr(peg$currPos, 2) === peg$c160) {
+          s1 = peg$c160;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+          if (peg$silentFails === 0) { peg$fail(peg$c161); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -2037,7 +2066,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c159(s3);
+            s1 = peg$c162(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2059,25 +2088,25 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c160) {
-        s1 = peg$c160;
+      if (input.substr(peg$currPos, 8) === peg$c163) {
+        s1 = peg$c163;
         peg$currPos += 8;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c162) {
-          s1 = peg$c162;
+        if (input.substr(peg$currPos, 2) === peg$c165) {
+          s1 = peg$c165;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c164();
+        s1 = peg$c167();
       }
       s0 = s1;
 
@@ -2088,12 +2117,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c165) {
-        s1 = peg$c165;
+      if (input.substr(peg$currPos, 3) === peg$c168) {
+        s1 = peg$c168;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c166); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2101,7 +2130,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s3);
+            s1 = peg$c170(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2125,45 +2154,45 @@ zlsa.atc.Parser = (function() {
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s2 = peg$c168;
+        s2 = peg$c171;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c172); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s2 = peg$c170;
+          s2 = peg$c173;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c174); }
         }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 5) === peg$c172) {
-          s3 = peg$c172;
+        if (input.substr(peg$currPos, 5) === peg$c175) {
+          s3 = peg$c175;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c173); }
+          if (peg$silentFails === 0) { peg$fail(peg$c176); }
         }
         if (s3 === peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c174) {
-            s3 = peg$c174;
+          if (input.substr(peg$currPos, 4) === peg$c177) {
+            s3 = peg$c177;
             peg$currPos += 4;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c175); }
+            if (peg$silentFails === 0) { peg$fail(peg$c178); }
           }
           if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c176) {
-              s3 = peg$c176;
+            if (input.substr(peg$currPos, 2) === peg$c179) {
+              s3 = peg$c179;
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c177); }
+              if (peg$silentFails === 0) { peg$fail(peg$c180); }
             }
           }
         }
@@ -2183,7 +2212,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c178();
+        s2 = peg$c181();
       }
       s1 = s2;
       if (s1 !== peg$FAILED) {
@@ -2207,12 +2236,12 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c179) {
-        s1 = peg$c179;
+      if (input.substr(peg$currPos, 4) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c180); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2220,7 +2249,7 @@ zlsa.atc.Parser = (function() {
           s3 = peg$parsestring();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c181(s3);
+            s1 = peg$c184(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2242,34 +2271,34 @@ zlsa.atc.Parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 7) === peg$c182) {
-        s1 = peg$c182;
+      if (input.substr(peg$currPos, 7) === peg$c185) {
+        s1 = peg$c185;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c184) {
-          s1 = peg$c184;
+        if (input.substr(peg$currPos, 2) === peg$c187) {
+          s1 = peg$c187;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c186) {
-            s1 = peg$c186;
+          if (input.substr(peg$currPos, 3) === peg$c189) {
+            s1 = peg$c189;
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c187); }
+            if (peg$silentFails === 0) { peg$fail(peg$c190); }
           }
         }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c188();
+        s1 = peg$c191();
       }
       s0 = s1;
 
@@ -2280,28 +2309,28 @@ zlsa.atc.Parser = (function() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c189) {
-        s1 = peg$c189;
+      if (input.substr(peg$currPos, 4) === peg$c192) {
+        s1 = peg$c192;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c190); }
+        if (peg$silentFails === 0) { peg$fail(peg$c193); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c191) {
-          s1 = peg$c191;
+        if (input.substr(peg$currPos, 4) === peg$c194) {
+          s1 = peg$c194;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+          if (peg$silentFails === 0) { peg$fail(peg$c195); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 119) {
-            s1 = peg$c193;
+            s1 = peg$c196;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c194); }
+            if (peg$silentFails === 0) { peg$fail(peg$c197); }
           }
         }
       }
@@ -2312,7 +2341,7 @@ zlsa.atc.Parser = (function() {
           s4 = peg$parsestring();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c119(s4);
+            s3 = peg$c122(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2327,7 +2356,7 @@ zlsa.atc.Parser = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c195(s2);
+          s1 = peg$c198(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2348,54 +2377,54 @@ zlsa.atc.Parser = (function() {
       s1 = peg$parsewhiteSpace();
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 4) === peg$c196) {
-          s3 = peg$c196;
+        if (input.substr(peg$currPos, 4) === peg$c199) {
+          s3 = peg$c199;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 108) {
-            s3 = peg$c134;
+            s3 = peg$c137;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+            if (peg$silentFails === 0) { peg$fail(peg$c138); }
           }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c102();
+          s3 = peg$c105();
         }
         s2 = s3;
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c198) {
-            s3 = peg$c198;
+          if (input.substr(peg$currPos, 5) === peg$c201) {
+            s3 = peg$c201;
             peg$currPos += 5;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+            if (peg$silentFails === 0) { peg$fail(peg$c202); }
           }
           if (s3 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 114) {
-              s3 = peg$c200;
+              s3 = peg$c203;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c201); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c105();
+            s3 = peg$c108();
           }
           s2 = s3;
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c202(s2);
+          s1 = peg$c205(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2445,7 +2474,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203(s1);
+        s1 = peg$c206(s1);
       }
       s0 = s1;
 
@@ -2457,22 +2486,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c204.test(input.charAt(peg$currPos))) {
+      if (peg$c207.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c205); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c204.test(input.charAt(peg$currPos))) {
+          if (peg$c207.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c205); }
+            if (peg$silentFails === 0) { peg$fail(peg$c208); }
           }
         }
       } else {
@@ -2494,33 +2523,33 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c170;
+        s3 = peg$c173;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c120.test(input.charAt(peg$currPos))) {
+        if (peg$c123.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c124); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c120.test(input.charAt(peg$currPos))) {
+            if (peg$c123.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
           }
         } else {
@@ -2529,30 +2558,30 @@ zlsa.atc.Parser = (function() {
         if (s4 !== peg$FAILED) {
           s5 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s6 = peg$c206;
+            s6 = peg$c209;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c207); }
+            if (peg$silentFails === 0) { peg$fail(peg$c210); }
           }
           if (s6 !== peg$FAILED) {
             s7 = [];
-            if (peg$c120.test(input.charAt(peg$currPos))) {
+            if (peg$c123.test(input.charAt(peg$currPos))) {
               s8 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s8 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
             if (s8 !== peg$FAILED) {
               while (s8 !== peg$FAILED) {
                 s7.push(s8);
-                if (peg$c120.test(input.charAt(peg$currPos))) {
+                if (peg$c123.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c124); }
                 }
               }
             } else {
@@ -2594,7 +2623,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c208();
+        s1 = peg$c211();
       }
       s0 = s1;
 
@@ -2606,22 +2635,22 @@ zlsa.atc.Parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c209.test(input.charAt(peg$currPos))) {
+      if (peg$c212.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c210); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c209.test(input.charAt(peg$currPos))) {
+          if (peg$c212.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c210); }
+            if (peg$silentFails === 0) { peg$fail(peg$c213); }
           }
         }
       } else {
@@ -2641,22 +2670,22 @@ zlsa.atc.Parser = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c204.test(input.charAt(peg$currPos))) {
+      if (peg$c207.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c205); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c204.test(input.charAt(peg$currPos))) {
+          if (peg$c207.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c205); }
+            if (peg$silentFails === 0) { peg$fail(peg$c208); }
           }
         }
       } else {
@@ -2665,7 +2694,7 @@ zlsa.atc.Parser = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c211); }
+        if (peg$silentFails === 0) { peg$fail(peg$c214); }
       }
 
       return s0;
@@ -2678,33 +2707,33 @@ zlsa.atc.Parser = (function() {
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s3 = peg$c170;
+        s3 = peg$c173;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c120.test(input.charAt(peg$currPos))) {
+        if (peg$c123.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c124); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c120.test(input.charAt(peg$currPos))) {
+            if (peg$c123.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
           }
         } else {
@@ -2728,7 +2757,7 @@ zlsa.atc.Parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c212(s1);
+        s1 = peg$c215(s1);
       }
       s0 = s1;
 

--- a/assets/scripts/util.js
+++ b/assets/scripts/util.js
@@ -1035,3 +1035,11 @@ function update_aircraft_eids() {
     prop.aircraft.list[i].fms.my_aircrafts_eid = i; // update eid in aircraft's fms
   }
 }
+
+// Remove the specified aircraft and perform cleanup operations
+function aircraft_remove(aircraft) {
+  prop.aircraft.callsigns.splice(prop.aircraft.callsigns.indexOf(aircraft.callsign), 1);
+  prop.aircraft.list.splice(prop.aircraft.list.indexOf(aircraft), 1);
+  update_aircraft_eids();
+  aircraft.cleanup();
+}

--- a/tools/compile-parser.html
+++ b/tools/compile-parser.html
@@ -38,9 +38,9 @@ aircraftCommand
 
 aircraftSubCommand
 = (whiteSpace command:(cmdAbort / cmdDirect / cmdAltitude / cmdClearedAsFiled / cmdClimbViaSID /
-                       cmdDebug / cmdDescendViaSTAR / cmdFix / cmdHeading / cmdHold / cmdLand /
-                       cmdMoveDataBlock / cmdRoute / cmdReRoute / cmdSayRoute / cmdSID / cmdSpeed /
-                       cmdSTAR / cmdTakeoff / cmdTaxi) {return command})+ 
+                       cmdDebug / cmdDelete / cmdDescendViaSTAR / cmdFix / cmdHeading / cmdHold /
+                       cmdLand / cmdMoveDataBlock / cmdRoute / cmdReRoute / cmdSayRoute / cmdSID /
+                       cmdSpeed / cmdSTAR / cmdTakeoff / cmdTaxi) {return command})+ 
 
 cmdAbort
   = "abort" {return ["abort"]}
@@ -67,6 +67,9 @@ cmdClimbViaSID
 
 cmdDebug
   = "debug" _ "log" {return ["debug"]}
+
+cmdDelete
+  = ("delete" / "del" / "kill") {return ["delete"]}
 
 cmdDescendViaSTAR
   = ("descendviastar" / "dvs") {return ["descendViaSTAR"]}

--- a/tools/compile-parser.html
+++ b/tools/compile-parser.html
@@ -38,9 +38,9 @@ aircraftCommand
 
 aircraftSubCommand
 = (whiteSpace command:(cmdAbort / cmdDirect / cmdAltitude / cmdClearedAsFiled / cmdClimbViaSID /
-                       cmdDebug / cmdDelete / cmdDescendViaSTAR / cmdFix / cmdHeading / cmdHold /
-                       cmdLand / cmdMoveDataBlock / cmdRoute / cmdReRoute / cmdSayRoute / cmdSID /
-                       cmdSpeed / cmdSTAR / cmdTakeoff / cmdTaxi) {return command})+ 
+                       cmdDebug / cmdDelete / cmdDescendViaSTAR / cmdFix / cmdFlyPresentHeading /
+                       cmdHeading / cmdHold / cmdLand / cmdMoveDataBlock / cmdRoute / cmdReRoute /
+                       cmdSayRoute / cmdSID / cmdSpeed / cmdSTAR / cmdTakeoff / cmdTaxi) {return command})+ 
 
 cmdAbort
   = "abort" {return ["abort"]}
@@ -79,6 +79,9 @@ cmdDirect
 
 cmdFix
   = (("fix" / "f" / "track") {return "fix"}) fixToken+
+
+cmdFlyPresentHeading
+  = "fph" {return ['flyPresentHeading']}
 
 cmdHeading
   = cmd:(cmdHeadingShort / cmdHeadingLong)

--- a/tools/compile-parser.html
+++ b/tools/compile-parser.html
@@ -69,7 +69,7 @@ cmdDebug
   = "debug" _ "log" {return ["debug"]}
 
 cmdDescendViaSTAR
-  = ("descendviastart" / "dvs") {return ["descendViaSTAR"]}
+  = ("descendviastar" / "dvs") {return ["descendViaSTAR"]}
 
 cmdDirect
   = (("direct" / "dct" / "pd") {return "direct"}) fixToken
@@ -105,8 +105,17 @@ cmdHold
              fix ? fix[2] : null]}
 
 cmdLand
-  = cmd:(("land" / "l" / "ils" / "i") {return "land"}) 
+  = cmd: (cmdLandShort / cmdLandLong)
+    {return [cmd[0], cmd[1], cmd[2]]}
+
+cmdLandLong
+  = cmd:(("land" / "l" / "ils") {return "land"}) 
     arg:(whiteSpace variant:[a-z]i? arg:string {return [variant, arg]})
+    { return [cmd, arg[0], arg[1]] }
+
+cmdLandShort
+  = cmd:("\u2B50" {return "land"}) 
+    arg:(variant:[a-z]i? arg:string {return [variant, arg]})
     { return [cmd, arg[0], arg[1]] }
 
 cmdMoveDataBlock


### PR DESCRIPTION
Resolves #620, #621, #638.

Adds two new commands, `fph` for "fly present heading" and `kill / del / delete` to remove an aircraft from the simulation. Also removes commands' case sensitivity and returns to service the asterisk shortkey for approach clearances.
### Demo: [erikquinn.github.io/atc/b/command-parser-improvements](http://erikquinn.github.io/atc/b/command-parser-improvements)
